### PR TITLE
WIP: Preprocessing using child process to write instead of aggregating values in main process

### DIFF
--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -214,12 +214,20 @@ def main():
         # Merge partial datasets into the main dataset.
         for bin_path in bin_paths:
             print(bin_path)
+            # We need to finalize the partial datasets first
+            partial_builder = indexed_dataset.make_builder(
+                indexed_dataset.data_file_path(bin_path),
+                impl=args.dataset_impl,
+                vocab_size=tokenizer.vocab_size
+            )
+            partial_builder.finalize(indexed_dataset.index_file_path(bin_path))
             builder.merge_file_(bin_path)
         builder.finalize(indexed_dataset.index_file_path(output_files_key))
 
         # Remove partial datasets
         for bin_path in bin_paths:
             os.remove(indexed_dataset.data_file_path(bin_path))
+            os.remove(indexed_dataset.index_file_path(bin_path))
 
 
 if __name__ == '__main__':

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -203,14 +203,17 @@ def main():
 
     print("Finished writing, time to index.")
     for key , bin_paths in output_dataset_builders.items():
+        output_bin_files_key = "{}_{}_{}.bin".format(args.output_prefix, key, level)
         output_idx_files_key = "{}_{}_{}.idx".format(args.output_prefix, key, level)
+        builder = indexed_dataset.make_builder(
+            output_bin_files_key,
+            impl=args.dataset_impl,
+            vocab_size=tokenizer.vocab_size
+        )
         for bin_path in bin_paths:
             print(bin_path)
-            indexed_dataset.make_builder(
-                bin_path,
-                impl=args.dataset_impl,
-                vocab_size=tokenizer.vocab_size
-            ).finalize(output_idx_files_key)
+            builder.merge_file_(bin_path)
+        builder.finalize(output_idx_files_key)
 
 if __name__ == '__main__':
     main()

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -210,10 +210,17 @@ def main():
             impl=args.dataset_impl,
             vocab_size=tokenizer.vocab_size
         )
+
+        # Merge partial datasets into the main dataset.
         for bin_path in bin_paths:
             print(bin_path)
             builder.merge_file_(bin_path)
         builder.finalize(output_idx_files_key)
+
+        # Remove partial datasets
+        for bin_path in bin_paths:
+            os.remove(bin_path)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
 - Related to: #1 
 
Instead of using a Semaphore to handle child processes processing inputs too fast, we instead more the "writing" from the main process to the child process. And then the main process handles the indexing.

WIP: there's a problem with finalizing dataset builder as it needs to be the same instance all the way ... (otherwise `_size` is wrong)

cc @TevenLeScao 