### PR TITLE
Tokenizer batch encode

### DIFF
--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -103,6 +103,9 @@ class AbstractTokenizer(ABC):
     def tokenize(self, text):
         pass
 
+    def batch_tokenize(self, texts):
+        return [self.tokenize(text) for text in texts]
+
     def detokenize(self, token_ids):
         raise NotImplementedError('detokenizer is not implemented for {} '
                                   'tokenizer'.format(self.name))
@@ -322,6 +325,9 @@ class _AutoTokenizer(AbstractTokenizer):
 
     def tokenize(self, text):
         return self.tokenizer.encode(text)
+
+    def batch_tokenize(self, texts):
+        return self.tokenizer.batch_encode_plus(texts, return_attention_mask=False)["input_ids"]
 
     def detokenize(self, token_ids):
         return self.tokenizer.decode(token_ids)

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -80,16 +80,17 @@ class Encoder(object):
         ids = {}
         for key in self.args.json_keys:
             text = data[key]
-            doc_ids = []
-            for sentence in Encoder.splitter.tokenize(text):
-                sentence_ids = Encoder.tokenizer.tokenize(sentence)
-                if len(sentence_ids) > 0:
-                    doc_ids.append(sentence_ids)
+            sentences = Encoder.splitter.tokenize(text)
+            doc_ids = [
+                sentence_ids
+                for sentence_ids in Encoder.tokenizer(sentences)
+                if len(sentence_ids) > 0
+            ]
             if len(doc_ids) > 0 and self.args.append_eod:
                 doc_ids[-1].append(Encoder.tokenizer.eod)
             ids[key] = doc_ids
         return ids, len(json_line)
-
+    
 def get_args():
     parser = argparse.ArgumentParser()
     group = parser.add_argument_group(title='input data')

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -83,14 +83,14 @@ class Encoder(object):
             sentences = Encoder.splitter.tokenize(text)
             doc_ids = [
                 sentence_ids
-                for sentence_ids in Encoder.tokenizer(sentences)
+                for sentence_ids in Encoder.tokenizer.batch_tokenize(sentences)
                 if len(sentence_ids) > 0
             ]
             if len(doc_ids) > 0 and self.args.append_eod:
                 doc_ids[-1].append(Encoder.tokenizer.eod)
             ids[key] = doc_ids
         return ids, len(json_line)
-    
+
 def get_args():
     parser = argparse.ArgumentParser()
     group = parser.add_argument_group(title='input data')


### PR DESCRIPTION
This allows to leverage HF's tokenizers' `batch_encode` method. I observed a 30% speedup on my colab (with 2 workers ... so I don't know how it translates for c4 with 16/32 workers), so we might need to test out with long runs? Also #18 should be able to leverage this feature nicely as each work write directly on disk.