### PR TITLE
Fix inconsistent merge

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -302,6 +302,7 @@ class IndexedDatasetBuilder(object):
         begin = self.dim_offsets[-1]
         for dim_offset in index.dim_offsets[1:]:
             self.dim_offsets.append(begin + dim_offset)
+        self.doc_idx.extend(index.doc_idx)
 
         with open(data_file_path(another_file), 'rb') as f:
             while True:
@@ -559,8 +560,8 @@ class MMapIndexedDatasetBuilder(object):
         total_len = len(index.sizes)+len(self._sizes)
         print(f"    concat {another_file} size={len(index.sizes)} for a total size of {total_len}")
 
-        for size in index.sizes:
-            self._sizes.append(size)
+        self._sizes.extend(index.sizes)
+        self._doc_idx.extend(index.doc_idx)
 
         # Concatenate data
         with open(data_file_path(another_file), 'rb') as f:

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -302,7 +302,7 @@ class IndexedDatasetBuilder(object):
         begin = self.dim_offsets[-1]
         for dim_offset in index.dim_offsets[1:]:
             self.dim_offsets.append(begin + dim_offset)
-        self.doc_idx.extend(index.doc_idx)
+        self.doc_idx.extend( (len(self.sizes) + index.doc_idx)[1:] )
 
         with open(data_file_path(another_file), 'rb') as f:
             while True:
@@ -561,7 +561,7 @@ class MMapIndexedDatasetBuilder(object):
         print(f"    concat {another_file} size={len(index.sizes)} for a total size of {total_len}")
 
         self._sizes.extend(index.sizes)
-        self._doc_idx.extend(index.doc_idx)
+        self._doc_idx.extend( (len(self._sizes) + index.doc_idx)[1:] )
 
         # Concatenate data
         with open(data_file_path(another_file), 'rb') as f:

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -295,6 +295,8 @@ class IndexedDatasetBuilder(object):
         index = IndexedDataset(another_file)
         assert index.dtype == self.dtype
 
+        offset = len(self.sizes)
+
         begin = self.data_offsets[-1]
         for offset in index.data_offsets[1:]:
             self.data_offsets.append(begin + offset)
@@ -302,7 +304,7 @@ class IndexedDatasetBuilder(object):
         begin = self.dim_offsets[-1]
         for dim_offset in index.dim_offsets[1:]:
             self.dim_offsets.append(begin + dim_offset)
-        self.doc_idx.extend( (len(self.sizes) + index.doc_idx)[1:] )
+        self.doc_idx.extend( (offset + index.doc_idx)[1:] )
 
         with open(data_file_path(another_file), 'rb') as f:
             while True:
@@ -560,8 +562,9 @@ class MMapIndexedDatasetBuilder(object):
         total_len = len(index.sizes)+len(self._sizes)
         print(f"    concat {another_file} size={len(index.sizes)} for a total size of {total_len}")
 
+        offset = len(self._sizes)
         self._sizes.extend(index.sizes)
-        self._doc_idx.extend( (len(self._sizes) + index.doc_idx)[1:] )
+        self._doc_idx.extend( (offset + index.doc_idx)[1:] )
 
         # Concatenate data
         with open(data_file_path(another_file), 'rb') as f:


### PR DESCRIPTION
Merges didn't take in account document ids (whatever they were used for). This PR fixes this. Maybe we should fix this upstream?

Small colab to check that merge or without merge should be the same
https://colab.research.google.com/drive/1haC-r0t0TnhYlx0y3j3yqXsYdNAjUv2A#scrollTo=7jAoQyI9A5D-

Thanks @ontocord for spotting the issue!