### PR TITLE
Add LRU cache, add faster tokenization

### DIFF
--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -152,8 +152,12 @@ class GPT2Tokenizer(object):
             **kwargs)
         return tokenizer
 
+    #max_token_len_cache determines whether a normalized token will be cached. Increasing
+    #this may make things faster but will also take more memory. The upper bound of
+    #the normalized token cache is fixed at 1000000 tokens, but could be less than 
+    #this depending on the max_token_len_cache.
     def __init__(self, vocab_file, merges_file, errors='replace',
-                 special_tokens=None, max_len=None):
+                 special_tokens=None, max_len=None, max_token_len_cache=9):
         self.max_len = max_len if max_len is not None else int(1e12)
         self.encoder = json.load(open(vocab_file))
         self.decoder = {v: k for k, v in self.encoder.items()}
@@ -171,6 +175,7 @@ class GPT2Tokenizer(object):
         self.special_tokens = {}
         self.special_tokens_decoder = {}
         self.set_special_tokens(special_tokens)
+        self.max_token_len_cache=max_token_len_cache
 
     def __len__(self):
         return len(self.encoder) + len(self.special_tokens)
@@ -239,8 +244,9 @@ class GPT2Tokenizer(object):
           ret = [bpe_token for bpe_token in self.bpe(token).split(' ')]
           return ret
 
-    def tokenize(self, text, max_token_len_cache=9, tokenize_chinese_chars=False):
+    def tokenize(self, text):
         """ Tokenize a string. """
+        max_token_len_cache = self.max_token_len_cache
         bpe_tokens = []
         if sys.version_info[0] == 2:
           for token in re.findall(self.pat, text):        

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -152,10 +152,11 @@ class GPT2Tokenizer(object):
             **kwargs)
         return tokenizer
 
-    #max_token_len_cache determines whether a normalized token will be cached. Increasing
-    #this may make things faster but will also take more memory. The upper bound of
-    #the normalized token cache is fixed at 1000000 tokens, but could be less than 
-    #this depending on the max_token_len_cache.
+    """
+    max_token_len_cache determines whether a normalized token will be cached. It tries to only store shorter token in the cache, with the heuristic that they are more frequent. Increasing
+    this may make tokenization faster but will also take more memory. The upper bound of
+    the normalized token cache is fixed at 1 000 000 tokens.
+    """
     def __init__(self, vocab_file, merges_file, errors='replace',
                  special_tokens=None, max_len=None, max_token_len_cache=9):
         self.max_len = max_len if max_len is not None else int(1e12)

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -338,9 +338,6 @@ class GPT2Tokenizer(object):
                 tokens.append(self.decoder[i])
         return tokens
 
-    def encode_old(self, text):
-        return self.convert_tokens_to_ids(self.tokenize_old(text))
-
     def encode(self, text):
         return self.convert_tokens_to_ids(self.tokenize(text))
 

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -197,8 +197,6 @@ class GPT2Tokenizer(object):
     
     @lru_cache(1_000_000)
     def bpe(self, token):
-        #if token in self.cache:
-        #    return self.cache[token]
         word = tuple(token)
         pairs = get_pairs(word)
 

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -176,7 +176,7 @@ class GPT2Tokenizer(object):
         self.special_tokens = {}
         self.special_tokens_decoder = {}
         self.set_special_tokens(special_tokens)
-        self.max_token_len_cache=max_token_len_cache
+        self.max_token_len_cache = max_token_len_cache
 
     def __len__(self):
         return len(self.encoder) + len(self.special_tokens)

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -254,10 +254,10 @@ class GPT2Tokenizer(object):
               bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
           return bpe_tokens
         for token in re.findall(self.pat, text):
-           if len(token) <= max_token_len_cache:
-                bpe_tokens.extend(self.normalize_token_and_cache(token))
-           else: 
-                bpe_tokens.extend(self.normalize_token(token))
+          if len(token) <= max_token_len_cache:
+              bpe_tokens.extend(self.normalize_token_and_cache(token))
+          else: 
+              bpe_tokens.extend(self.normalize_token(token))
         return bpe_tokens
       
     def convert_tokens_to_ids(self, tokens):

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -163,8 +163,6 @@ class GPT2Tokenizer(object):
         bpe_data = open(merges_file, encoding='utf-8').read().split('\n')[1:-1]
         bpe_merges = [tuple(merge.split()) for merge in bpe_data]
         self.bpe_ranks = dict(zip(bpe_merges, range(len(bpe_merges))))
-        #self.cache = {}
-        #self.normalized_cache = {}
         # Should haved added re.IGNORECASE so BPE merges can happen for
         # capitalized versions of contractions
         self.pat = re.compile(
@@ -191,7 +189,7 @@ class GPT2Tokenizer(object):
         self.special_tokens_decoder = {v: k for k, v in self.special_tokens.items()}
         logger.info("Special tokens {}".format(self.special_tokens))
     
-    @lru_cache(1000000)
+    @lru_cache(1_000_000)
     def bpe(self, token):
         #if token in self.cache:
         #    return self.cache[token]
@@ -230,57 +228,13 @@ class GPT2Tokenizer(object):
             else:
                 pairs = get_pairs(word)
         word = ' '.join(word)
-        #self.cache[token] = word
         return word
       
-    # copied from https://github.com/huggingface/transformers/blob/master/src/transformers/models/bert/tokenization_bert.py
-    def _tokenize_chinese_chars(self, text):
-        """Adds whitespace around any CJK character."""
-        # original note from the Bert Tokenizer: 
-        # This was added on November 1st, 2018 for the multilingual and Chinese
-        # models. This is also applied to the English models now, but it doesn't
-        # matter since the English models were not trained on any Chinese data
-        # and generally don't have any Chinese data in them (there are Chinese
-        # characters in the vocabulary because Wikipedia does have some Chinese
-        # words in the English Wikipedia.).
-        output = []
-        for char in text:
-            cp = ord(char)
-            if self._is_chinese_char(cp):
-                output.append(" ")
-                output.append(char)
-                output.append(" ")
-            else:
-                output.append(char)
-        return "".join(output)
-      
-    #copied from https://github.com/huggingface/transformers/blob/master/src/transformers/models/bert/tokenization_bert.py
-    def _is_chinese_char(self, cp):
-        """Checks whether CP is the codepoint of a CJK character."""
-        # This defines a "chinese character" as anything in the CJK Unicode block:
-        #   https://en.wikipedia.org/wiki/CJK_Unified_Ideographs_(Unicode_block)
-        #
-        # Note that the CJK Unicode block is NOT all Japanese and Korean characters,
-        # despite its name. The modern Korean Hangul alphabet is a different block,
-        # as is Japanese Hiragana and Katakana. Those alphabets are used to write
-        # space-separated words, so they are not treated specially and handled
-        # like the all of the other languages.
-        if (
-            (cp >= 0x4E00 and cp <= 0x9FFF)
-            or (cp >= 0x3400 and cp <= 0x4DBF)  #
-            or (cp >= 0x20000 and cp <= 0x2A6DF)  #
-            or (cp >= 0x2A700 and cp <= 0x2B73F)  #
-            or (cp >= 0x2B740 and cp <= 0x2B81F)  #
-            or (cp >= 0x2B820 and cp <= 0x2CEAF)  #
-            or (cp >= 0xF900 and cp <= 0xFAFF)
-            or (cp >= 0x2F800 and cp <= 0x2FA1F)  #
-        ):  #
-            return True
-
-        return False
-      
-    @lru_cache(1000000)
-    def normalize_token_py3(self, token):
+    @lru_cache(1_000_000)
+    def normalize_token_and_cache(self, token):
+        return self.normalize_token(token)
+    
+    def normalize_token(self, token):
           token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
           ret = [bpe_token for bpe_token in self.bpe(token).split(' ')]
           return ret
@@ -289,20 +243,15 @@ class GPT2Tokenizer(object):
         """ Tokenize a string. """
         bpe_tokens = []
         if sys.version_info[0] == 2:
-          if tokenize_chinese_chars:
-            text = self._tokenize_chinese_chars(text)
           for token in re.findall(self.pat, text):        
               token = ''.join(self.byte_encoder[ord(b)] for b in token)
               bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
           return bpe_tokens
         for token in re.findall(self.pat, text):
-           if tokenize_chinese_chars:
-              text = self._tokenize_chinese_chars(text)
            if len(token) <= max_token_len_cache:
-                bpe_tokens.extend(self.normalize_token_py3(token))
+                bpe_tokens.extend(self.normalize_token_and_cache(token))
            else: 
-                token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
-                bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
+                bpe_tokens.extend(self.normalize_token(token))
         return bpe_tokens
       
     def convert_tokens_to_ids(self, tokens):

--- a/megatron/tokenizer/gpt2_tokenization.py
+++ b/megatron/tokenizer/gpt2_tokenization.py
@@ -152,13 +152,14 @@ class GPT2Tokenizer(object):
             **kwargs)
         return tokenizer
 
-    """
-    max_token_len_cache determines whether a normalized token will be cached. It tries to only store shorter token in the cache, with the heuristic that they are more frequent. Increasing
-    this may make tokenization faster but will also take more memory. The upper bound of
-    the normalized token cache is fixed at 1 000 000 tokens.
-    """
+
     def __init__(self, vocab_file, merges_file, errors='replace',
                  special_tokens=None, max_len=None, max_token_len_cache=9):
+        """
+        max_token_len_cache determines whether a normalized token will be cached. It tries to only store shorter tokens in the cache, 
+        with the heuristic that they are more frequent. Increasing this may make tokenization faster but will also take more memory. 
+        The upper bound of the normalized token cache is fixed at 1_000_000 tokens.
+        """
         self.max_len = max_len if max_len is not None else int(1e12)
         self.encoder = json.load(open(vocab_file))
         self.decoder = {v: k for k, v in self.encoder.items()}

--- a/tools/preprocess_data.py
+++ b/tools/preprocess_data.py
@@ -21,10 +21,9 @@ import multiprocessing
 import os
 import sys
 
-from megatron.data.indexed_dataset import best_fitting_dtype
-
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              os.path.pardir)))
+from megatron.data.indexed_dataset import best_fitting_dtype
 import time
 
 import torch


### PR DESCRIPTION
Note that this supprts LRU caching in Python3 only. In python2, the caching is removed from BPE altogether. 