### PR TITLE
Group tensorboard metrics

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -244,7 +244,7 @@ class Timers:
         assert normalizer > 0.0
         for name in names:
             value = self.timers[name].elapsed(reset=reset) / normalizer
-            writer.add_scalar('time/' + name + '-time', value, iteration)
+            writer.add_scalar(f'time/{name}-time', value, iteration)
 
     def log(self, names, normalizer=1.0, reset=True):
         """Log a group of timers."""

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -244,7 +244,7 @@ class Timers:
         assert normalizer > 0.0
         for name in names:
             value = self.timers[name].elapsed(reset=reset) / normalizer
-            writer.add_scalar(name + '-time', value, iteration)
+            writer.add_scalar('time/' + name + '-time', value, iteration)
 
     def log(self, names, normalizer=1.0, reset=True):
         """Log a group of timers."""

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -584,7 +584,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed()
         elapsed_time_per_iteration = elapsed_time / total_iterations
-        if writer and is_last_rank():
+        if writer and is_last_rank(): # Changed `torch.distributed.get_rank() == 0` to `is_last_rank()` as a writing condition
             if args.log_timers_to_tensorboard:
                 writer.add_scalar('iteration-time/iteration-time (s)',
                                   elapsed_time_per_iteration, iteration)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -547,6 +547,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     # Tensorboard values.
     if writer and (iteration % args.tensorboard_log_interval == 0 ) and \
        is_last_rank():
+        writer.add_scalar('steps-vs-samples/y=steps,x=samples', iteration, args.consumed_train_samples)
+        writer.add_scalar('steps-vs-samples/y=samples,x=steps', args.consumed_train_samples, iteration)
         if args.log_learning_rate_to_tensorboard:
             writer.add_scalar('learning-rate/learning-rate', learning_rate, iteration)
             writer.add_scalar('learning-rate/learning-rate vs samples', learning_rate,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -829,7 +829,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
             if args.log_validation_ppl_to_tensorboard:
                 writer.add_scalar(f'lm-loss-validation/{key} validation ppl', ppl,
                                   iteration)
-                writer.add_scalar('lm-loss-validation/{} validation ppl vs samples'.format(key),
+                writer.add_scalar(f'lm-loss-validation/{key} validation ppl vs samples',
                                   ppl, args.consumed_train_samples)
 
     length = len(string) + 1

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -823,7 +823,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
             writer.add_scalar(f'lm-loss-validation/{key} validation',
                               total_loss_dict[key].item(),
                               iteration)
-            writer.add_scalar('lm-loss-validation/{} validation vs samples'.format(key),
+            writer.add_scalar(f'lm-loss-validation/{key} validation vs samples',
                               total_loss_dict[key].item(),
                               args.consumed_train_samples)
             if args.log_validation_ppl_to_tensorboard:

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -584,7 +584,9 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed()
         elapsed_time_per_iteration = elapsed_time / total_iterations
-        if writer and is_last_rank(): # Changed `torch.distributed.get_rank() == 0` to `is_last_rank()` as a writing condition
+        # Changed `torch.distributed.get_rank() == 0` to `is_last_rank()` as a writing condition.
+        # Bug fix as detailed in this issue: https://github.com/NVIDIA/Megatron-LM/issues/129
+        if writer and is_last_rank():
             if args.log_timers_to_tensorboard:
                 writer.add_scalar('iteration-time/iteration-time (s)',
                                   elapsed_time_per_iteration, iteration)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -827,7 +827,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
                               total_loss_dict[key].item(),
                               args.consumed_train_samples)
             if args.log_validation_ppl_to_tensorboard:
-                writer.add_scalar('lm-loss-validation/{} validation ppl'.format(key), ppl,
+                writer.add_scalar(f'lm-loss-validation/{key} validation ppl', ppl,
                                   iteration)
                 writer.add_scalar('lm-loss-validation/{} validation ppl vs samples'.format(key),
                                   ppl, args.consumed_train_samples)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -816,16 +816,16 @@ def evaluate_and_print_results(prefix, forward_step_func,
         ppl = math.exp(min(20, total_loss_dict[key].item()))
         string += '{} PPL: {:.6E} | '.format(key, ppl)
         if writer and is_last_rank():
-            writer.add_scalar('{} validation'.format(key),
+            writer.add_scalar('lm-loss-validation/{} validation'.format(key),
                               total_loss_dict[key].item(),
                               iteration)
-            writer.add_scalar('{} validation vs samples'.format(key),
+            writer.add_scalar('lm-loss-validation/{} validation vs samples'.format(key),
                               total_loss_dict[key].item(),
                               args.consumed_train_samples)
             if args.log_validation_ppl_to_tensorboard:
-                writer.add_scalar('{} validation ppl'.format(key), ppl,
+                writer.add_scalar('lm-loss-validation/{} validation ppl'.format(key), ppl,
                                   iteration)
-                writer.add_scalar('{} validation ppl vs samples'.format(key),
+                writer.add_scalar('lm-loss-validation/{} validation ppl vs samples'.format(key),
                                   ppl, args.consumed_train_samples)
 
     length = len(string) + 1

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -820,7 +820,7 @@ def evaluate_and_print_results(prefix, forward_step_func,
         ppl = math.exp(min(20, total_loss_dict[key].item()))
         string += '{} PPL: {:.6E} | '.format(key, ppl)
         if writer and is_last_rank():
-            writer.add_scalar('lm-loss-validation/{} validation'.format(key),
+            writer.add_scalar(f'lm-loss-validation/{key} validation',
                               total_loss_dict[key].item(),
                               iteration)
             writer.add_scalar('lm-loss-validation/{} validation vs samples'.format(key),

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -584,10 +584,12 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed()
         elapsed_time_per_iteration = elapsed_time / total_iterations
-        if writer and torch.distributed.get_rank() == 0:
+        if writer and is_last_rank():
             if args.log_timers_to_tensorboard:
-                writer.add_scalar('iteration-time',
+                writer.add_scalar('iteration-time/iteration-time (s)',
                                   elapsed_time_per_iteration, iteration)
+                writer.add_scalar('iteration-time/iteration-time (s) vs samples',
+                                  elapsed_time_per_iteration, args.consumed_train_samples)
         log_string = ' iteration {:8d}/{:8d} |'.format(
             iteration, args.train_iters)
         log_string += ' consumed samples: {:12d} |'.format(

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -548,32 +548,32 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     if writer and (iteration % args.tensorboard_log_interval == 0 ) and \
        is_last_rank():
         if args.log_learning_rate_to_tensorboard:
-            writer.add_scalar('learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate vs samples', learning_rate,
+            writer.add_scalar('learning-rate/learning-rate', learning_rate, iteration)
+            writer.add_scalar('learning-rate/learning-rate vs samples', learning_rate,
                               args.consumed_train_samples)
         if args.log_batch_size_to_tensorboard:
-            writer.add_scalar('batch-size', batch_size, iteration)
-            writer.add_scalar('batch-size vs samples', batch_size,
+            writer.add_scalar('batch-size/batch-size', batch_size, iteration)
+            writer.add_scalar('batch-size/batch-size vs samples', batch_size,
                               args.consumed_train_samples)
         for key in loss_dict:
-            writer.add_scalar(key , loss_dict[key], iteration)
-            writer.add_scalar(key + ' vs samples', loss_dict[key],
+            writer.add_scalar(f"lm-loss-training/{key}", loss_dict[key], iteration)
+            writer.add_scalar(f"lm-loss-training/{key}" + ' vs samples', loss_dict[key],
                               args.consumed_train_samples)
         if args.log_loss_scale_to_tensorboard:
-            writer.add_scalar('loss-scale', loss_scale, iteration)
-            writer.add_scalar('loss-scale vs samples', loss_scale,
+            writer.add_scalar('loss-scale/loss-scale', loss_scale, iteration)
+            writer.add_scalar('loss-scale/loss-scale vs samples', loss_scale,
                               args.consumed_train_samples)
         if grad_norm is not None:
-            writer.add_scalar('grad-norm', grad_norm, iteration)
-            writer.add_scalar('grad-norm vs samples', grad_norm,
+            writer.add_scalar('grad-norm/grad-norm', grad_norm, iteration)
+            writer.add_scalar('grad-norm/grad-norm vs samples', grad_norm,
                               args.consumed_train_samples)
         if num_zeros_in_grad is not None:
-            writer.add_scalar('num-zeros', num_zeros_in_grad, iteration)
-            writer.add_scalar('num-zeros vs samples', num_zeros_in_grad,
+            writer.add_scalar('num-zeros/num-zeros', num_zeros_in_grad, iteration)
+            writer.add_scalar('num-zeros/num-zeros vs samples', num_zeros_in_grad,
                               args.consumed_train_samples)
         if params_norm is not None:
-            writer.add_scalar('params-norm', params_norm, iteration)
-            writer.add_scalar('params-norm vs samples', params_norm,
+            writer.add_scalar('params-norm/params-norm', params_norm, iteration)
+            writer.add_scalar('params-norm/params-norm vs samples', params_norm,
                               args.consumed_train_samples)
         if args.log_timers_to_tensorboard:
             timers.write(timers_to_log, writer, iteration,
@@ -772,7 +772,7 @@ def evaluate(forward_step_func, data_iterator, model, verbose=False):
                     forward_backward_func = forward_backward_pipelining_without_interleaving
             else:
                 forward_backward_func = forward_backward_no_pipelining
-            
+
             if args.deepspeed:
                 # DeepSpeed uses eval_batch() and already aggregates losses.
                 assert isinstance(model, list) and len(model) == 1
@@ -782,7 +782,7 @@ def evaluate(forward_step_func, data_iterator, model, verbose=False):
                 loss_dicts = forward_backward_func(
                     forward_step_func, data_iterator, model, optimizer=None,
                     timers=None, forward_only=True)
-            
+
             if mpu.is_pipeline_last_stage(ignore_virtual=True):
                 # Reduce across processes.
                 for loss_dict in loss_dicts:


### PR DESCRIPTION
As discussed in issue #38:

- I grouped the metrics into a few groups
- Added speed metrics (under `iteration-time`)
- Added the mapping iteration (or step) vs samples

A preview of the tensorboard on a dummy training can be found [here](https://tensorboard.dev/experiment/54F4T0NVREO5RbLhbIMPcQ).