### PR TITLE
Add GLU variants

### DIFF
--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -9,6 +9,7 @@ class _GLUBaseModule(nn.Module):
         self.activation_fn = activation_fn
     
     def forward(self, x):
+        # dim=-1 breaks in pt<1.10
         x1, x2 = x.chunk(2, dim=(x.ndim-1))
         return x1 * self.activation_fn(x2)
 

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -9,7 +9,7 @@ class _GLUBaseModule(nn.Module):
         self.activation_fn = activation_fn
     
     def forward(self, x):
-        # dim=-1 breaks in pt<1.10
+        # dim=-1 breaks in jit for pt<1.10
         x1, x2 = x.chunk(2, dim=(x.ndim-1))
         return x1 * self.activation_fn(x2)
 

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -18,23 +18,19 @@ class _GLUVariant(nn.Module):
 
 class Bilinear(_GLUVariant):
     def __init__(self):
-        super().__init__(lambda x: x)()
+        super().__init__(lambda x: x)
 
 
 class GEGLU(_GLUVariant):
     def __init__(self):
-        super().__init__(F.gelu)()
+        super().__init__(F.gelu)
 
 
 class ReGLU(_GLUVariant):
     def __init__(self):
-        super().__init__(F.relu)()
+        super().__init__(F.relu)
 
 
 class SwiGLU(_GLUVariant):
     def __init__(self):
-        super().__init__(F.silu)()
-
-
-
-    
+        super().__init__(F.silu)

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -1,0 +1,40 @@
+from torch import nn
+from torch.nn import functional as F
+
+
+class _GLUVariant(nn.Module):
+    def __init__(self, activation_fn):
+        super().__init__()
+        self.activation_fn = activation_fn
+    
+    def forward(self, x, bias=None):
+        x1, x2 = x.chunk(2, dim=-1)
+        if bias is not None:
+            b1, b2 = bias.chunk(2, dim=-1)
+            x1 = x1 + b1
+            x2 = x2 + b2
+        return x1 * self.activation_fn(x2)
+
+
+class Bilinear(_GLUVariant):
+    def __init__(self):
+        super().__init__(lambda x: x)()
+
+
+class GEGLU(_GLUVariant):
+    def __init__(self):
+        super().__init__(F.gelu)()
+
+
+class ReGLU(_GLUVariant):
+    def __init__(self):
+        super().__init__(F.relu)()
+
+
+class SwiGLU(_GLUVariant):
+    def __init__(self):
+        super().__init__(F.silu)()
+
+
+
+    

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -9,7 +9,7 @@ class _GLUBaseModule(nn.Module):
         self.activation_fn = activation_fn
     
     def forward(self, x):
-        x1, x2 = x.chunk(2, dim=2)
+        x1, x2 = x.chunk(2, dim=(x.ndim-1))
         return x1 * self.activation_fn(x2)
 
 

--- a/megatron/model/activations.py
+++ b/megatron/model/activations.py
@@ -9,7 +9,7 @@ class _GLUBaseModule(nn.Module):
         self.activation_fn = activation_fn
     
     def forward(self, x):
-        x1, x2 = x.chunk(2, dim=-1)
+        x1, x2 = x.chunk(2, dim=2)
         return x1 * self.activation_fn(x2)
 
 

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,0 +1,43 @@
+import unittest
+import math
+
+import torch
+
+from megatron.model.activations import liglu, geglu, reglu, swiglu
+
+
+class TestActivations(unittest.TestCase):
+    def setUp(self):
+        self.x = torch.tensor([0.1, -0.7])
+
+    def test_shapes(self):
+        batch_size = 8
+        seq_len = 100
+        num_channels = 768
+        x = torch.randn(batch_size, seq_len, num_channels)
+        # glu should halve the last dimension
+        output_shape = [batch_size, seq_len, num_channels // 2]
+        for activation_fn in [liglu, geglu, reglu, swiglu]:
+            output = activation_fn(x)
+            self.assertEqual(list(output.shape), output_shape)
+
+    def test_liglu(self):
+        expected = torch.tensor([-0.07])
+        self.assertEqual(liglu(self.x), expected)
+    
+    def test_geglu(self):
+        """compute gelu output according to its definition"""
+        normal_cdf = lambda x: 0.5 * (1 + math.erf(x / math.sqrt(2)))
+        gelu_output = self.x[1] * normal_cdf(self.x[1].item())
+        expected = self.x[0] * gelu_output
+        self.assertAlmostEqual(geglu(self.x).item(), expected.item())
+
+    def test_reglu(self):
+        expected = torch.tensor([0.])
+        self.assertEqual(reglu(self.x), expected)
+
+    def test_swiglu(self):
+        """compute swish output according to its definition"""
+        swish_output = self.x[1] / (1 + math.pow(math.e, -self.x[1].item()))
+        expected = self.x[0] * swish_output
+        self.assertAlmostEqual(swiglu(self.x).item(), expected.item())

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,5 +1,5 @@
-import unittest
 import math
+import unittest
 
 import torch
 
@@ -23,7 +23,7 @@ class TestActivations(unittest.TestCase):
 
     def test_liglu(self):
         expected = torch.tensor([-0.07])
-        self.assertEqual(liglu(self.x), expected)
+        torch.testing.assert_equal(liglu(self.x), expected)
     
     def test_geglu(self):
         """compute gelu output according to its definition"""
@@ -31,10 +31,10 @@ class TestActivations(unittest.TestCase):
         gelu_output = self.x[1] * normal_cdf(self.x[1].item())
         expected = self.x[0] * gelu_output
         self.assertAlmostEqual(geglu(self.x).item(), expected.item())
-
+        
     def test_reglu(self):
         expected = torch.tensor([0.])
-        self.assertEqual(reglu(self.x), expected)
+        torch.testing.assert_equal(reglu(self.x), expected)
 
     def test_swiglu(self):
         """compute swish output according to its definition"""

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,43 +1,43 @@
-import math
+import random
 import unittest
 
 import torch
+from torch.nn import functional as F
 
 from megatron.model.activations import liglu, geglu, reglu, swiglu
+
+from .utils import set_seed
 
 
 class TestActivations(unittest.TestCase):
     def setUp(self):
-        self.x = torch.tensor([0.1, -0.7])
+        """setup an input of reasonable size"""
+        set_seed()
+        self.batch_size = random.randint(2, 64)
+        self.seq_len = random.randint(256, 1025)
+        self.num_channels = random.randint(1, 384) * 2
+        self.x = torch.randn(self.batch_size, self.seq_len, self.num_channels)
+        self.x1, self.x2 = self.x.chunk(2, dim=-1)
 
     def test_shapes(self):
-        batch_size = 8
-        seq_len = 100
-        num_channels = 768
-        x = torch.randn(batch_size, seq_len, num_channels)
         # glu should halve the last dimension
-        output_shape = [batch_size, seq_len, num_channels // 2]
+        output_shape = [self.batch_size, self.seq_len, self.num_channels // 2]
         for activation_fn in [liglu, geglu, reglu, swiglu]:
-            output = activation_fn(x)
+            output = activation_fn(self.x)
             self.assertEqual(list(output.shape), output_shape)
 
     def test_liglu(self):
-        expected = torch.tensor([-0.07])
+        expected = self.x1 * self.x2
         torch.testing.assert_equal(liglu(self.x), expected)
-    
+ 
     def test_geglu(self):
-        """compute gelu output according to its definition"""
-        normal_cdf = lambda x: 0.5 * (1 + math.erf(x / math.sqrt(2)))
-        gelu_output = self.x[1] * normal_cdf(self.x[1].item())
-        expected = self.x[0] * gelu_output
-        self.assertAlmostEqual(geglu(self.x).item(), expected.item())
+        expected = self.x1 * F.gelu(self.x2)
+        torch.testing.assert_equal(geglu(self.x), expected)
         
     def test_reglu(self):
-        expected = torch.tensor([0.])
+        expected = self.x1 * F.relu(self.x2)
         torch.testing.assert_equal(reglu(self.x), expected)
 
     def test_swiglu(self):
-        """compute swish output according to its definition"""
-        swish_output = self.x[1] / (1 + math.pow(math.e, -self.x[1].item()))
-        expected = self.x[0] * swish_output
-        self.assertAlmostEqual(swiglu(self.x).item(), expected.item())
+        expected = self.x1 * F.silu(self.x2)
+        torch.testing.assert_equal(swiglu(self.x), expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed=42):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)


### PR DESCRIPTION
This PR addresses #44. Specifically, it implements the following activation functions:

* LiGLU
* GEGLU
* ReGLU
* SwiGLU

Nomenclature-wise, Bilinear seems to be synonymous with LiGLU. 