### PR TITLE
use HuggingFace Datasets as source to build Megatron data files

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -365,15 +365,16 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
                     # create numpy array of desired numpy datatype
                     pointers = np.array(sizes, dtype=npdtype)
 
-                    # scale each element by its dtype size
-                    dtype_size = dtype().itemsize
-                    pointers *= dtype_size
+                    if len(sizes) > 0:
+                        # scale each element by its dtype size
+                        dtype_size = dtype().itemsize
+                        pointers *= dtype_size
 
-                    # in-place prefix scan to compute byte offsets
-                    np.cumsum(pointers, axis=0, out=pointers)
+                        # in-place prefix scan to compute byte offsets
+                        np.cumsum(pointers, axis=0, out=pointers)
 
-                    # zero-base the prefix scan (exclusive scan)
-                    pointers -= pointers[0]
+                        # zero-base the prefix scan (exclusive scan)
+                        pointers -= pointers[0]
 
                     return pointers
 

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -62,46 +62,7 @@ except ImportError:
     nltk_available = False
 
 from megatron.tokenizer import build_tokenizer
-from megatron.data import indexed_dataset
 from megatron.data.indexed_dataset import data_file_path, index_file_path, make_builder
-
-def get_start_end(num, rank, num_ranks):
-    """Compute start and end index values to evenly divide num items
-    among ranks.
-
-    If num is not evenly divisible by num_ranks, ranks from
-    [0,remainder) will each be assigned one extra item.
-    Returns a (start, end) tuple, such that the calling rank
-    should take items in a list[start:end]
-
-    Parameters
-    ----------
-    num : int
-      Number of items to be divided
-    rank : int
-      Rank of the calling process
-    num_ranks : int
-      Number of processes among which to divide items
-
-    Returns
-    -------
-    int
-      start index value
-    int
-      end index value
-    """
-
-    num_per_rank = num // num_ranks
-    remainder = num % num_per_rank
-    if rank < remainder:
-        start = (num_per_rank + 1) * rank;
-        end = start + (num_per_rank + 1)
-    else:
-        start = (num_per_rank + 1) * remainder + num_per_rank * (rank - remainder);
-        end = start + num_per_rank
-    if end > num:
-        end = num
-    return start, end
 
 # https://stackoverflow.com/questions/33139531/preserve-empty-lines-with-nltks-punkt-tokenizer
 class CustomLanguageVars(nltk.tokenize.punkt.PunktLanguageVars):
@@ -124,9 +85,8 @@ class Encoder(object):
     def __init__(self, args):
         self.args = args
 
-    def initializer(self):
-        # Use Encoder class as a container for global data
-        Encoder.tokenizer = build_tokenizer(self.args)
+        self.tokenizer = build_tokenizer(self.args)
+
         if self.args.split_sentences:
             if not nltk_available:
                 print("NLTK is not available to split sentences.")
@@ -134,26 +94,25 @@ class Encoder(object):
             splitter = nltk.load("tokenizers/punkt/english.pickle")
             if self.args.keep_newlines:
                 # this prevents punkt from eating newlines after sentences
-                Encoder.splitter = nltk.tokenize.punkt.PunktSentenceTokenizer(
+                self.splitter = nltk.tokenize.punkt.PunktSentenceTokenizer(
                     train_text = splitter._params,
                     lang_vars = CustomLanguageVars())
             else:
-                Encoder.splitter = splitter
-
+                self.splitter = splitter
         else:
-            Encoder.splitter = IdentitySplitter()
+            self.splitter = IdentitySplitter()
 
     def encode_text(self, text):
         ids = {}
         for key in self.args.columns:
             doc_ids = []
-            for sentence in Encoder.splitter.tokenize(text):
-                sentence_ids = Encoder.tokenizer.tokenize(sentence)
+            for sentence in self.splitter.tokenize(text):
+                sentence_ids = self.tokenizer.tokenize(sentence)
                 if len(sentence_ids) > 0:
                     doc_ids.append(sentence_ids)
             if len(doc_ids) > 0:
                 if self.args.append_eod:
-                    doc_ids[-1].append(Encoder.tokenizer.eod)
+                    doc_ids[-1].append(self.tokenizer.eod)
                 ids[key] = doc_ids
         return ids, len(text)
 
@@ -191,7 +150,6 @@ def get_args():
     group.add_argument('--append-eod', action='store_true',
                        help='Append an <eod> token to the end of a document.')
 
-
     group = parser.add_argument_group(title='output data')
     group.add_argument('--output-prefix', type=str, required=True,
                        help='Path to binary output file without suffix')
@@ -220,17 +178,36 @@ def get_args():
 
     return args
 
-def get_rank_size(args):
-    if args.mpi_comm:
-        rank = args.mpi_comm.Get_rank()
-        size = args.mpi_comm.Get_size()
-        return rank, size
+def init_distributed(args):
+    """Determine which distributed runtime to use and connect up processes"""
+    # use mpi4py instead of torch.distributed if requested
+    use_mpi = False
+    if args.mpi4py:
+        try:
+            from mpi4py import MPI
+            use_mpi = True
+        except:
+            print(f"ERROR: mpi4py requested, but failed to import, falling back to torch.distributed.")
+
+    # select our distributed runtime (MPI or torch.distributed)
+    # lookup our process rank and the group size
+    # some functions like build_tokenizer use args.rank to filter stdout messages
+    args.mpi_comm = None
+    if use_mpi:
+        args.MPI = MPI
+        args.mpi_comm = MPI.COMM_WORLD
+        args.rank = args.mpi_comm.Get_rank()
+        args.numranks = args.mpi_comm.Get_size()
     else:
-        rank = dist.get_rank()
-        size = dist.get_world_size()
-        return rank, size
+        proc_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+        proc_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
+        dist.init_process_group(args.torch_backend, init_method="env://",
+            rank=proc_rank, world_size=proc_size)
+        args.rank = dist.get_rank()
+        args.numranks = dist.get_world_size()
 
 def barrier(args):
+    """Globally synchronize all processes."""
     if args.mpi_comm:
         args.mpi_comm.barrier()
     else:
@@ -248,8 +225,7 @@ def bcast(args, vals, root=0):
 
         # allocate a tensor of appropriate size
         # initialize tensor with list values on root
-        rank, _ = get_rank_size(args)
-        if rank == root:
+        if args.rank == root:
             tvals = torch.tensor(vals, dtype=torch.int64)
         else:
             tvals = torch.zeros(length[0], dtype=torch.int64)
@@ -271,7 +247,7 @@ def all_sum_(args, vals):
 def all_true(args, val):
     """Returns True if all procs input True, False otherwise"""
     if args.mpi_comm:
-        inval = np.array([bool(val)], dtype=np.bool_)
+        inval = np.array([val], dtype=np.bool_)
         outval = np.zeros_like(inval)
         args.mpi_comm.Allreduce(inval, outval, op=args.MPI.LAND)
         return bool(outval[0])
@@ -282,12 +258,17 @@ def all_true(args, val):
 
 def load_dset(args):
     # Avoid downloading datasets unless explicitly requested.
-    # The environment variable is processed when datasets is imported,
+    # To disable downloads, we set $HF_DATASETS_OFFLINE=1.
+    # The HF_DATASETS_OFFLINE environment variable is processed when datasets is imported,
     # so we must set it before the import statement.
-    # Alternatively, one could set datasets.config.HF_DATASETS_OFFLINE
-    # directly, but that feels like a bigger hack.
+    # We allow the user to override default behavior if they explictly set $HF_DATASETS_OFFLINE.
     if not args.download and 'HF_DATASETS_OFFLINE' not in os.environ:
+        # sets HF_DATASETS_OFFLINE within the environment of this script
         os.environ['HF_DATASETS_OFFLINE'] = "1"
+
+        # Alternatively, one could set datasets.config.HF_DATASETS_OFFLINE.
+        # This seems to work even after the import statement,
+        # but it feels like a bigger hack.
         #datasets.config.HF_DATASETS_OFFLINE = 1
 
     # import datasets after potentially setting environment variables
@@ -295,16 +276,15 @@ def load_dset(args):
     from datasets.utils.file_utils import OfflineModeIsEnabled
 
     # silence info messages from all procs except rank 0 
-    proc_rank, _ = get_rank_size(args)
-    if proc_rank != 0:
+    if args.rank != 0:
         logging.set_verbosity(logging.ERROR)
 
     # Load the specified HuggingFace dataset.
     # Give rank 0 a head start in case the dataset is not already cached.
     success = True
     dsetname = args.input
-    if proc_rank == 0:
-        print("Opening dataset", dsetname)
+    if args.rank == 0:
+        print(f"Opening dataset {dsetname}")
         try:
             dset = load_dataset(dsetname, split=args.split, keep_in_memory=None)
         except OfflineModeIsEnabled:
@@ -317,12 +297,11 @@ def load_dset(args):
     # determine whether rank 0 succeeded in loading the dataset
     success = all_true(args, success)
     if not success:
-        if proc_rank == 0:
-            print(f"ERROR: Rank 0 failed to load {dsetname}")
         return None
 
-    # rank 0 succeeded, attempt to load dataset on all other ranks
-    if proc_rank != 0:
+    # Rank 0 succeeded, attempt to load dataset on all other ranks.
+    # This should load from cache now.
+    if args.rank != 0:
         try:
             dset = load_dataset(dsetname, split=args.split, keep_in_memory=None)
         except:
@@ -333,7 +312,7 @@ def load_dset(args):
     # verify that all ranks loaded the dataset
     success = all_true(args, success)
     if not success:
-        if proc_rank == 0:
+        if args.rank == 0:
             print(f"ERROR: At least one process failed to load {dsetname}")
         return None
 
@@ -363,99 +342,76 @@ def select_sample_list(args, dset_size):
     idx = bcast(args, idx, root=0)
     return idx
 
-def main():
-    args = get_args()
-    startup_start = time.time()
+def get_start_end(num, rank, num_ranks):
+    """Compute start and end index values to evenly divide num items
+    among ranks.
 
-    # use mpi4py instead of torch.distributed if requested
-    if args.mpi4py:
-        try:
-            from mpi4py import MPI
-            use_mpi = True
-        except:
-            print(f"ERROR: mpi4py requested, but failed to import, falling back to torch.distributed.")
-            use_mpi = False
+    If num is not evenly divisible by num_ranks, ranks from
+    [0,remainder) will each be assigned one extra item.
+    Returns a (start, end) tuple, such that the calling rank
+    should take items in a list[start:end]
 
-    # select our distributed runtime (MPI or torch.distributed)
-    # and lookup our process rank and the group size
-    args.mpi_comm = None
-    if use_mpi:
-        args.MPI = MPI
-        args.mpi_comm = MPI.COMM_WORLD
+    Parameters
+    ----------
+    num : int
+      Number of items to be divided
+    rank : int
+      Rank of the calling process
+    num_ranks : int
+      Number of processes among which to divide items
+
+    Returns
+    -------
+    int
+      start index value
+    int
+      end index value
+    """
+
+    num_per_rank = num // num_ranks
+    remainder = num - num_per_rank * num_ranks
+    if rank < remainder:
+        start = (num_per_rank + 1) * rank;
+        end = start + (num_per_rank + 1)
     else:
-        proc_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
-        proc_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-        dist.init_process_group(args.torch_backend, init_method="env://",
-            rank=proc_rank, world_size=proc_size)
-    proc_rank, proc_size = get_rank_size(args)
+        start = (num_per_rank + 1) * remainder + num_per_rank * (rank - remainder);
+        end = start + num_per_rank
+    return start, end
 
-    # some functions like build_tokenizer use args.rank to filter stdout messages
-    args.rank = proc_rank
-
-    # load the dataset
-    dset = load_dset(args)
-    if dset is None:
-        return
-    if proc_rank == 0:
-        print(dset)
-
-    # create sample index list,
-    # optionally shuffle the list,
-    # and optionally limit the sample count
-    idx = select_sample_list(args, len(dset))
-    
-    # identify list of features (column names) to use, e.g., ['text']
-    columns = args.columns
-
-    if nltk_available and args.split_sentences:
-        nltk.download("punkt", quiet=True)
-
-    encoder = Encoder(args)
-    tokenizer = build_tokenizer(args)
-
-    level = "document"
-    if args.split_sentences:
-        level = "sentence"
-
-    # wait for all ranks before stopping timer
-    barrier(args)
-    startup_end = time.time()
-    if proc_rank == 0:
-        print("Seconds to startup:", startup_end - startup_start)
-
-    # TODO: skip write phase and report success if rank has nothing to do
-
-    # set this to false on any problem so we can inform rank 0
+def rank_files_write(args, dset, idx, encoder):
     tokenize_start = time.time()
+
+    # we'll total up the number of docs, sentences, and bytes
+    # processed across all ranks
     dset_stats = np.zeros(3, dtype=np.int64) # docs, sentences, bytes
+
+    # we'll set this to false on any problem
     success = True
+
     try:
         # create data file for each rank
-        if proc_rank == 0:
-            print(f"Vocab size: {tokenizer.vocab_size}")
+        if args.rank == 0:
+            print(f"Vocab size: {args.vocab_size}")
             print(f"Output prefix: {args.output_prefix}")
         output_bin_files = {}
         output_idx_files = {}
         builders = {}
-        for key in columns:
-            filebase = "{}_{}_{}_{}".format(args.output_prefix, key, level, proc_rank)
+        for key in args.columns:
+            filebase = f"{args.output_prefix}_{key}_{args.level}_{args.rank}"
             output_bin_files[key] = data_file_path(filebase)
             output_idx_files[key] = index_file_path(filebase)
-            builders[key] = indexed_dataset.make_builder(output_bin_files[key],
-                                                   impl=args.dataset_impl,
-                                                   vocab_size=tokenizer.vocab_size)
+            builders[key] = make_builder(output_bin_files[key],
+                                         impl=args.dataset_impl,
+                                         vocab_size=args.vocab_size)
 
         # divide index list evenly among ranks
-        idx_start, idx_end = get_start_end(len(idx), proc_rank, proc_size)
+        idx_start, idx_end = get_start_end(len(idx), args.rank, args.numranks)
 
         # each rank tokenizes its samples and writes its own file
-        encoder.initializer()
-        for count, i in enumerate(range(idx_start, idx_end)):
-            # get current sample index
-            j = idx[i]
-            for key in columns:
+        for count, i in enumerate(idx[idx_start: idx_end]):
+            for key in args.columns:
                 # tokenize text for the given sample index
-                text = dset[j][key]
+                text = dset[i][key]
                 doc, bytes_processed = encoder.encode_text(text)
 
                 # add tokenized sequence to our data file
@@ -467,19 +423,19 @@ def main():
                     dset_stats[1] += len(sentences)
                 dset_stats[2] += bytes_processed
 
-            if proc_rank == 0 and args.log_interval and count > 0 and count % args.log_interval == 0:
+            if args.rank == 0 and args.log_interval and count % args.log_interval == 0:
                 current = time.time()
                 elapsed = current - tokenize_start
                 mbs = dset_stats[2] / elapsed / 1024 / 1024 if elapsed > 0.0 else 0.0
                 docs = dset_stats[0]
                 print(f"Rank 0 processed {docs} documents",
                       f"({docs/elapsed} docs/s, {mbs} MB/s).")
-                print(f"Estimated total processed {docs * proc_size} documents",
-                      f"({docs * proc_size / elapsed} docs/s, {mbs * proc_size} MB/s).",
+                print(f"Estimated total processed {docs * args.numranks} documents",
+                      f"({docs * args.numranks / elapsed} docs/s, {mbs * args.numranks} MB/s).",
                       flush=True)
 
         # finalize file of each rank
-        for key in columns:
+        for key in args.columns:
             builders[key].finalize(output_idx_files[key])
             del builders[key] # file closed in __del__
     except:
@@ -489,8 +445,10 @@ def main():
     # wait for all ranks to finish their files
     barrier(args)
     tokenize_end = time.time()
+
+    # compute total stats across all processes
     all_sum_(args, dset_stats)
-    if proc_rank == 0:
+    if args.rank == 0:
         secs = tokenize_end - tokenize_start
         docrate = dset_stats[0] / secs if secs > 0.0 else 0.0
         sentrate = dset_stats[1] / secs if secs > 0.0 else 0.0
@@ -502,71 +460,122 @@ def main():
 
     # allreduce to check whether all ranks wrote their part successfully
     success = all_true(args, success)
+    return success
 
-    # rank 0 merges and deletes all per-rank files
-    if proc_rank == 0:
-        # merge files if all ranks were successful
-        if success:
-            print("Merging rank files ...", flush=True)
-            merge_start = time.time()
-            numbytes = 0
+def rank_files_merge(args):
+    # rank 0 merges all per-rank files
+    if args.rank == 0:
+        print("Merging rank files ...", flush=True)
+        merge_start = time.time()
+        numbytes = 0
 
-            # define name of single file
-            for key in columns:
-                filebase = "{}_{}_{}".format(args.output_prefix, key, level)
-                output_bin_files[key] = data_file_path(filebase)
-                output_idx_files[key] = index_file_path(filebase)
-                builders[key] = indexed_dataset.make_builder(output_bin_files[key],
-                                                             impl=args.dataset_impl,
-                                                             vocab_size=tokenizer.vocab_size)
+        # define name of single file
+        output_bin_files = {}
+        output_idx_files = {}
+        builders = {}
+        for key in args.columns:
+            filebase = f"{args.output_prefix}_{key}_{args.level}"
+            output_bin_files[key] = data_file_path(filebase)
+            output_idx_files[key] = index_file_path(filebase)
+            builders[key] = make_builder(output_bin_files[key],
+                                         impl=args.dataset_impl,
+                                         vocab_size=args.vocab_size)
 
-            # merge all ranks into one file
-            for rank in range(proc_size):
-                for key in columns:
-                    infile = "{}_{}_{}_{}".format(args.output_prefix, key, level, rank)
-                    print("Merging file", infile, flush=True)
-                    binfile = data_file_path(infile)
-                    filesize = os.stat(binfile)[stat.ST_SIZE]
-                    numbytes += filesize
-                    builders[key].merge_file_(infile)
+        # merge all ranks into one file
+        for rank in range(args.numranks):
+            for key in args.columns:
+                infile = f"{args.output_prefix}_{key}_{args.level}_{rank}"
+                print(f"Merging file {infile}", flush=True)
+                builders[key].merge_file_(infile)
 
-            # finalize the merged file
-            print("Finalizing merged file ...", flush=True)
-            for key in columns:
-                builders[key].finalize(output_idx_files[key])
-                del builders[key] # file closed in __del__
+                # sum up the number of merged bytes
+                binfile = data_file_path(infile)
+                filesize = os.stat(binfile)[stat.ST_SIZE]
+                numbytes += filesize
 
-            merge_end = time.time()
-            secs = merge_end - merge_start
-            byterate = numbytes / secs if secs > 0.0 else 0.0
-            print("Seconds to merge:", merge_end - merge_start)
-            print(f"Merged {proc_size} files into {args.output_prefix}")
-            print(f"Bytes=", numbytes, "bytes/sec=", byterate)
-        else:
-            # If any process fails, we skip the merge since the resulting file would be invalid.
-            # We still delete files to clean up, since those might be invalid anyway.
-            print(f"ERROR: At least one process failed to write its file, skipping merge and cleaning up")
+        # finalize the merged file
+        print("Finalizing merged file ...", flush=True)
+        for key in args.columns:
+            builders[key].finalize(output_idx_files[key])
+            del builders[key] # file closed in __del__
 
-        # delete per-rank files, do this even on error
-        print("Deleting rank files ...", flush=True)
-        for rank in range(proc_size):
-            for key in columns:
-                filebase = "{}_{}_{}_{}".format(args.output_prefix, key, level, rank)
-
-                binfile = data_file_path(filebase)
-                try:
-                    os.remove(binfile)
-                except:
-                    pass
-
-                idxfile = index_file_path(filebase)
-                try:
-                    os.remove(idxfile)
-                except:
-                    pass
+        merge_end = time.time()
+        secs = merge_end - merge_start
+        byterate = numbytes / secs if secs > 0.0 else 0.0
+        print("Seconds to merge:", merge_end - merge_start)
+        print(f"Merged {args.numranks} files into {args.output_prefix}")
+        print(f"Bytes=", numbytes, "bytes/sec=", byterate)
 
     # hold everyone until rank 0 is done
     barrier(args)
+
+def rank_files_delete(args):
+    # delete per-rank files
+    if args.rank == 0:
+        print("Deleting rank files ...", flush=True)
+
+    for key in args.columns:
+        filebase = f"{args.output_prefix}_{key}_{args.level}_{args.rank}"
+
+        binfile = data_file_path(filebase)
+        if os.path.exists(binfile):
+            os.remove(binfile)
+
+        idxfile = index_file_path(filebase)
+        if os.path.exists(idxfile):
+            os.remove(idxfile)
+
+    # hold everyone until all are done
+    barrier(args)
+
+def main():
+    args = get_args()
+    startup_start = time.time()
+
+    # connect processes and cache our rank and number of procs in args
+    init_distributed(args)
+
+    # load the dataset
+    dset = load_dset(args)
+    if dset is None:
+        return
+    if args.rank == 0:
+        print(dset)
+
+    # create sample index list,
+    # optionally shuffle the list,
+    # and optionally limit the sample count
+    idx = select_sample_list(args, len(dset))
+    
+    if nltk_available and args.split_sentences:
+        nltk.download("punkt", quiet=True)
+
+    encoder = Encoder(args)
+    args.vocab_size = encoder.tokenizer.vocab_size
+
+    args.level = "document"
+    if args.split_sentences:
+        args.level = "sentence"
+
+    # wait for all ranks before stopping timer
+    barrier(args)
+    startup_end = time.time()
+    if args.rank == 0:
+        print("Seconds to startup:", startup_end - startup_start)
+
+    # have each rank write its file, returns False if any rank had a problem
+    success = rank_files_write(args, dset, idx, encoder)
+
+    # merge files if all ranks were successful writing their file
+    if success:
+        rank_files_merge(args)
+    elif args.rank == 0:
+        # If any process fails, we skip the merge since the resulting file would be invalid.
+        # We still delete files to clean up, since those might be invalid anyway.
+        print(f"ERROR: At least one process failed to write its file, skipping merge and cleaning up")
+
+    # delete per-rank files, do this even on error
+    rank_files_delete(args)
 
 if __name__ == '__main__':
     main()

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -1,0 +1,351 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Processing data for pretraining.
+
+This builds data files from a source HuggingFace dataset, e.g,
+
+  from datasets import load_dataset
+  dset = load_dataset('openwebtext')
+
+The implementation requires MPI and mpi4py, and it assumes that
+files are written to a global file system, such that one process
+can read a file written by another process.
+
+A list of sample index values for the source dataset are shuffled by rank 0,
+and the shuffled sequence is then broadcast to all ranks.
+Each process tokenizes a subset of samples and writes its output to a part file.
+After all ranks have finished, rank 0 merges and deletes the part files.
+
+To run:
+
+mpiexec -np 320 python preprocess_dataset_mpi.py \
+       --input openwebtext \
+       --output-prefix openwebtext-bert \
+       --vocab bert-large-uncased-vocab.txt \
+       --dataset-impl mmap \
+       --tokenizer-type BertWordPieceLowerCase \
+       --split-sentences
+"""
+
+import argparse
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             os.path.pardir)))
+import time
+
+import torch
+try:
+    import nltk
+    nltk_available = True
+except ImportError:
+    nltk_available = False
+
+from datasets import load_dataset, logging
+
+from megatron.tokenizer import build_tokenizer
+from megatron.data import indexed_dataset
+from megatron.data.indexed_dataset import infer_dataset_impl, MMapIndexedDataset, data_file_path, index_file_path
+
+import random
+from mpi4py import MPI
+
+mpi_comm = MPI.COMM_WORLD
+mpi_rank = mpi_comm.Get_rank()
+mpi_size = mpi_comm.Get_size()
+
+# compute start and end index values based on rank
+# evenly divide file count among procs
+def get_start_end(num, rank, num_ranks):
+    """Compute start and end index values to evenly divide num items
+    among ranks.
+
+    If num is not evenly divisible by num_ranks, ranks from
+    [0,remainder) will each be assigned one extra item.
+    Returns a (start, end) tuple, such that the calling rank
+    should take items in a list[start:end]
+
+    Parameters
+    ----------
+    num : int
+      Number of items to be divided
+    rank : int
+      Rank of the calling process
+    num_ranks : int
+      Number of processes among which to divide items
+
+    Returns
+    -------
+    int
+      start index value
+    int
+      end index value
+    """
+
+    num_per_rank = num // num_ranks
+    remainder = num - num_per_rank * num_ranks
+    if rank < remainder:
+        start = (num_per_rank + 1) * rank;
+        end = start + (num_per_rank+1)
+    else:
+        start = (num_per_rank + 1) * remainder + num_per_rank * (rank - remainder);
+        end = start + num_per_rank
+    if end > num:
+        end = num
+    return start, end
+
+# https://stackoverflow.com/questions/33139531/preserve-empty-lines-with-nltks-punkt-tokenizer
+class CustomLanguageVars(nltk.tokenize.punkt.PunktLanguageVars):
+
+    _period_context_fmt = r"""
+        \S*                          # some word material
+        %(SentEndChars)s             # a potential sentence ending
+        \s*                       #  <-- THIS is what I changed
+        (?=(?P<after_tok>
+            %(NonWord)s              # either other punctuation
+            |
+            (?P<next_tok>\S+)     #  <-- Normally you would have \s+ here
+        ))"""
+
+class IdentitySplitter(object):
+    def tokenize(self, *text):
+        return text
+
+class Encoder(object):
+    def __init__(self, args):
+        self.args = args
+
+    def initializer(self):
+        # Use Encoder class as a container for global data
+        Encoder.tokenizer = build_tokenizer(self.args)
+        if self.args.split_sentences:
+            if not nltk_available:
+                print("NLTK is not available to split sentences.")
+                exit()
+            splitter = nltk.load("tokenizers/punkt/english.pickle")
+            if self.args.keep_newlines:
+                # this prevents punkt from eating newlines after sentences
+                Encoder.splitter = nltk.tokenize.punkt.PunktSentenceTokenizer(
+                    train_text = splitter._params,
+                    lang_vars = CustomLanguageVars())
+            else:
+                Encoder.splitter = splitter
+
+        else:
+            Encoder.splitter = IdentitySplitter()
+
+    def encode_text(self, text):
+        ids = {}
+        for key in ['text']:
+            doc_ids = []
+            for sentence in Encoder.splitter.tokenize(text):
+                sentence_ids = Encoder.tokenizer.tokenize(sentence)
+                if len(sentence_ids) > 0:
+                    doc_ids.append(sentence_ids)
+            if len(doc_ids) > 0:
+                if self.args.append_eod:
+                    doc_ids[-1].append(Encoder.tokenizer.eod)
+                ids[key] = doc_ids
+        return ids, len(text)
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    group = parser.add_argument_group(title='input data')
+    group.add_argument('--input', type=str, required=True,
+                       help='Dataset name')
+    group.add_argument('--columns', nargs='+', default=['text'],
+                       help='space separate listed of column names to extract from dataset')
+    group.add_argument('--split-sentences', action='store_true',
+                       help='Split documents into sentences.')
+    group.add_argument('--keep-newlines', action='store_true',
+                       help='Keep newlines between sentences when splitting.')
+
+    group = parser.add_argument_group(title='tokenizer')
+    group.add_argument('--tokenizer-type', type=str, required=True,
+                       choices=['BertWordPieceLowerCase','BertWordPieceCase',
+                                'GPT2BPETokenizer'],
+                       help='What type of tokenizer to use.')
+    group.add_argument('--vocab-file', type=str, default=None,
+                       help='Path to the vocab file')
+    group.add_argument('--merge-file', type=str, default=None,
+                       help='Path to the BPE merge file (if necessary).')
+    group.add_argument('--append-eod', action='store_true',
+                       help='Append an <eod> token to the end of a document.')
+
+
+    group = parser.add_argument_group(title='output data')
+    group.add_argument('--output-prefix', type=str, required=True,
+                       help='Path to binary output file without suffix')
+    group.add_argument('--dataset-impl', type=str, default='mmap',
+                       choices=['lazy', 'cached', 'mmap'])
+
+    args = parser.parse_args()
+    args.keep_empty = False
+
+    if args.tokenizer_type.lower().startswith('bert'):
+        if not args.split_sentences:
+            print("Bert tokenizer detected, are you sure you don't want to split sentences?")
+
+    # some default/dummy values for the tokenizer
+    args.rank = 0
+    args.make_vocab_size_divisible_by = 128
+    args.model_parallel_size = 1
+
+    return args
+
+def main():
+    args = get_args()
+    startup_start = time.time()
+
+    # typically: ['text']
+    columns = args.columns
+
+    # some functions like build_tokenizer use args.rank to filter stdout messages
+    args.rank = mpi_rank
+
+    # silence info messages from all procs except rank 0 
+    if mpi_rank != 0:
+        logging.set_verbosity(logging.ERROR)
+
+    # open the specified HuggingFace dataset
+    dsetname = args.input
+    if mpi_rank == 0:
+        print("Opening dataset", dsetname)
+    dset = load_dataset(dsetname, split="train", keep_in_memory=None)
+    dset_size = len(dset)
+    mpi_comm.barrier()
+    if mpi_rank == 0:
+        print(dset)
+
+    # shuffle sample index list on rank 0, bcast to all ranks
+    idx = []
+    if mpi_rank == 0:
+      idx = [int(x) for x in range(dset_size)]
+      random.shuffle(idx)
+    idx = mpi_comm.bcast(idx, root=0)
+    
+    # divide index list evenly among ranks
+    start, end = get_start_end(len(idx), mpi_rank, mpi_size)
+
+    if nltk_available and args.split_sentences:
+        nltk.download("punkt", quiet=True)
+
+    encoder = Encoder(args)
+    tokenizer = build_tokenizer(args)
+
+    level = "document"
+    if args.split_sentences:
+        level = "sentence"
+
+    # TODO: skip write phase and report success if rank has nothing to do
+
+    # create data file for each rank
+    if mpi_rank == 0:
+        print(f"Vocab size: {tokenizer.vocab_size}")
+        print(f"Output prefix: {args.output_prefix}")
+    output_bin_files = {}
+    output_idx_files = {}
+    builders = {}
+    for key in columns:
+        filebase = "{}_{}_{}_{}".format(args.output_prefix, key, level, mpi_rank)
+        output_bin_files[key] = data_file_path(filebase)
+        output_idx_files[key] = index_file_path(filebase)
+        builders[key] = indexed_dataset.make_builder(output_bin_files[key],
+                                               impl=args.dataset_impl,
+                                               vocab_size=tokenizer.vocab_size)
+
+    # wait to start timer until all ranks are ready
+    mpi_comm.barrier()
+    startup_end = time.time()
+    if mpi_rank == 0:
+        print("Time to startup:", startup_end - startup_start)
+
+    # each rank writes its own file
+    proc_start = time.time()
+    count = 0
+    total_bytes_processed = 0
+    encoder.initializer()
+    for i in range(start, end):
+        # tokenize text for the given sample index
+        j = idx[i]
+        text = dset[j]['text']
+        doc, bytes_processed = encoder.encode_text(text)
+
+        # add tokenized sequence to our data file
+        total_bytes_processed += bytes_processed
+        for key, sentences in doc.items():
+            for sentence in sentences:
+                builders[key].add_item(torch.IntTensor(sentence))
+            builders[key].end_document()
+
+    # finalize file of each rank
+    for key in columns:
+        builders[key].finalize(output_idx_files[key])
+        del builders[key] # file closed in __del__
+
+    # wait for all ranks to finish their files
+    mpi_comm.barrier()
+    proc_end = time.time()
+    if mpi_rank == 0:
+        print("Time to tokenize:", proc_end - proc_start)
+        print("Documents:", dset_size, "docs/sec: ", dset_size / (proc_end - proc_start))
+
+    # TODO: allreduce to ensure all ranks wrote their part successfully
+
+    # have rank 0 merge all files into one, and delete per rank files
+    if mpi_rank == 0:
+        print("Merging rank files ...", flush=True)
+        merge_start = time.time()
+
+        # define name of single file
+        for key in columns:
+            filebase = "{}_{}_{}".format(args.output_prefix, key, level)
+            output_bin_files[key] = data_file_path(filebase)
+            output_idx_files[key] = index_file_path(filebase)
+            builders[key] = indexed_dataset.make_builder(output_bin_files[key],
+                                                   impl=args.dataset_impl,
+                                                   vocab_size=tokenizer.vocab_size)
+
+        # merge all ranks into one file
+        for rank in range(mpi_size):
+            infile = "{}_{}_{}_{}".format(args.output_prefix, key, level, rank)
+            print("Merging file", infile, flush=True)
+            builders[key].merge_file_(infile)
+
+        # finalize the merged file
+        print("Finalizing merged file ...", flush=True)
+        for key in columns:
+            builders[key].finalize(output_idx_files[key])
+            del builders[key] # file closed in __del__
+
+        # delete per ranks files
+        print("Deleting rank files ...", flush=True)
+        for rank in range(mpi_size):
+            filebase = "{}_{}_{}_{}".format(args.output_prefix, key, level, rank)
+            binfile = data_file_path(filebase)
+            idxfile = index_file_path(filebase)
+            os.remove(binfile)
+            os.remove(idxfile)
+
+        merge_end = time.time()
+        print("Time to merge:", merge_end - merge_start)
+        print(f"Merged {mpi_size} datasets to {args.output_prefix}")
+
+    # hold everyone until rank 0 is done
+    mpi_comm.barrier()
+
+if __name__ == '__main__':
+    main()

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -63,7 +63,7 @@ except ImportError:
 
 from megatron.tokenizer import build_tokenizer
 from megatron.data import indexed_dataset
-from megatron.data.indexed_dataset import infer_dataset_impl, MMapIndexedDataset, data_file_path, index_file_path
+from megatron.data.indexed_dataset import data_file_path, index_file_path, make_builder
 
 def get_start_end(num, rank, num_ranks):
     """Compute start and end index values to evenly divide num items

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -272,7 +272,7 @@ def all_true(args, val):
     """Returns True if all procs input True, False otherwise"""
     if args.mpi_comm:
         inval = np.array([int(val)], dtype=np.int32)
-        outval = np.zeros(inval.shape, inval.dtype)
+        outval = np.zeros_like(inval)
         args.mpi_comm.Allreduce(inval, outval, op=MPI.LAND)
         return bool(outval[0])
     else:

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -20,7 +20,7 @@ This builds data files from a source HuggingFace dataset, e.g,
   from datasets import load_dataset
   dset = load_dataset('openwebtext')
 
-The implementation requires MPI and mpi4py, and it assumes that
+The implementation can use `mpi4py` or `torch.distributed` for node communication, and it assumes that
 files are written to a global file system, such that one process
 can read a file written by another process.
 

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -101,7 +101,7 @@ def get_start_end(num, rank, num_ranks):
     """
 
     num_per_rank = num // num_ranks
-    remainder = num - num_per_rank * num_ranks
+    remainder = num % num_per_rank
     if rank < remainder:
         start = (num_per_rank + 1) * rank;
         end = start + (num_per_rank+1)

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -24,8 +24,8 @@ The implementation requires MPI and mpi4py, and it assumes that
 files are written to a global file system, such that one process
 can read a file written by another process.
 
-A list of sample index values for the source dataset are shuffled by rank 0,
-and the shuffled sequence is then broadcast to all ranks.
+A list of sample index values from the source dataset are selected
+by rank 0 and broadcast to all ranks.
 Each process tokenizes a subset of samples and writes its output to a part file.
 After all ranks have finished, rank 0 merges and deletes the part files.
 
@@ -33,6 +33,8 @@ To run:
 
 mpiexec -np 320 python preprocess_dataset_mpi.py \
        --input openwebtext \
+       --shuffle \
+       --seed 100 \
        --output-prefix openwebtext-bert \
        --vocab bert-large-uncased-vocab.txt \
        --dataset-impl mmap \
@@ -170,17 +172,17 @@ def get_args():
     group.add_argument('--split', type=str, default='train',
                        help='Dataset split to select.')
     group.add_argument('--columns', nargs='+', default=['text'],
-                       help='space separate listed of column names to extract from dataset')
-    group.add_argument('--split-sentences', action='store_true',
-                       help='Split documents into sentences.')
-    group.add_argument('--keep-newlines', action='store_true',
-                       help='Keep newlines between sentences when splitting.')
+                       help='Space separate listed of column names to extract from dataset')
     group.add_argument('--count', type=int, default=None,
-                       help='Number of samples to select.')
+                       help='Limit the number of samples to select.')
     group.add_argument('--shuffle', action='store_true',
                        help='Shuffle samples before writing output files.')
     group.add_argument('--seed', type=int, default=None,
                        help='Seed to pass to random.seed for shuffle operations.')
+    group.add_argument('--split-sentences', action='store_true',
+                       help='Split documents into sentences.')
+    group.add_argument('--keep-newlines', action='store_true',
+                       help='Keep newlines between sentences when splitting.')
 
     group = parser.add_argument_group(title='tokenizer')
     group.add_argument('--tokenizer-type', type=str, required=True,

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -198,10 +198,7 @@ def init_distributed(args):
         args.rank = args.mpi_comm.Get_rank()
         args.numranks = args.mpi_comm.Get_size()
     else:
-        proc_rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
-        proc_size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-        dist.init_process_group(args.torch_backend, init_method="env://",
-            rank=proc_rank, world_size=proc_size)
+        dist.init_process_group(args.torch_backend, init_method="env://")
         args.rank = dist.get_rank()
         args.numranks = dist.get_world_size()
 

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -368,7 +368,7 @@ def main():
 
     # set this to false on any problem so we can inform rank 0
     tokenize_start = time.time()
-    dset_stats = np.zeros((3,), dtype=np.int64) # docs, sentences, bytes
+    dset_stats = np.zeros(3, dtype=np.int64) # docs, sentences, bytes
     success = True
     try:
         # create data file for each rank

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -157,10 +157,12 @@ def get_args():
                        choices=['lazy', 'cached', 'mmap'])
 
     group = parser.add_argument_group(title='runtime')
-    group.add_argument('--torch-backend', type=str, default='gloo', choices = ['gloo', 'mpi'],
-                       help='Select torch.distributed backend.')
     group.add_argument('--mpi4py', action='store_true',
                        help='Assume script has been launched as an MPI job, and use MPI for communication.')
+    group.add_argument('--torch-backend', type=str, default='gloo', choices = ['gloo', 'mpi'],
+                       help='Select torch.distributed backend.')
+    group.add_argument('--local_rank', type=int, default=None,
+                       help='Local rank of calling process on its node (from torch.distributed.launch).')
     group.add_argument('--log-interval', type=int, default=30,
                        help='Seconds between progress updates (0 to disable)')
 

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -289,7 +289,7 @@ def select_sample_list(args, dset_size):
     idx = []
     if args.rank == 0:
         # generate a list of all index values
-        idx = [int(x) for x in range(dset_size)]
+        idx = list(range(dset_size))
 
         # optionally shuffle
         if args.shuffle:

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -251,7 +251,7 @@ def bcast(args, vals, root=0):
         if rank == root:
             tvals = torch.tensor(vals, dtype=torch.int64)
         else:
-            tvals = torch.zeros([length[0]], dtype=torch.int64)
+            tvals = torch.zeros(length[0], dtype=torch.int64)
 
         # broadcast tensor from root, and return as a new list
         dist.broadcast(tvals, src=root)

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -95,7 +95,7 @@ def get_start_end(num, rank, num_ranks):
     remainder = num % num_per_rank
     if rank < remainder:
         start = (num_per_rank + 1) * rank;
-        end = start + (num_per_rank+1)
+        end = start + (num_per_rank + 1)
     else:
         start = (num_per_rank + 1) * remainder + num_per_rank * (rank - remainder);
         end = start + num_per_rank

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -276,7 +276,7 @@ def all_true(args, val):
         args.mpi_comm.Allreduce(inval, outval, op=MPI.LAND)
         return bool(outval[0])
     else:
-        rank, size = get_rank_size(args)
+        _, size = get_rank_size(args)
         tensor = torch.tensor([int(val)], dtype=torch.int32)
         dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
         return (tensor.tolist()[0] == size)

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -61,9 +61,7 @@ try:
 except ImportError:
     nltk_available = False
 
-# import datasets after potentially setting environment variables
-import datasets
-from datasets import load_dataset, logging
+from datasets import config, logging, load_dataset
 from datasets.utils.file_utils import OfflineModeIsEnabled
 
 from megatron.tokenizer import build_tokenizer
@@ -277,7 +275,7 @@ def load_dset(args):
         # Alternatively, one can set datasets.config.HF_DATASETS_OFFLINE=1.
         # That seems to work even after the import statement,
         # though this usage is not documented.
-        datasets.config.HF_DATASETS_OFFLINE = 1
+        config.HF_DATASETS_OFFLINE = 1
 
     # silence info messages from all procs except rank 0 
     if args.rank != 0:

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -295,7 +295,7 @@ def load_dset(args):
         except OfflineModeIsEnabled as e:
             print(f"ERROR: Cannot download '{dsetname}' since running in offline mode.")
             print(f"ERROR: If the dataset is large, it may be more efficient to download with a single process:")
-            print(f"ERROR:     from datasets import load_datasets")
+            print(f"ERROR:     from datasets import load_dataset")
             print(f"ERROR:     dset = load_dataset('{dsetname}')")
             print(f"ERROR: Alternatively, one can force this script to download by setting $HF_DATASETS_OFFLINE=0", flush=True)
             success = False


### PR DESCRIPTION
This is work in progress, but I'll post it early to get feedback.

This PR includes a few things at once.

Updates ``megatron/data/indexed_dataset.py`` to use ``numpy`` to compute sample offsets to improve speed while writing an index file.
- https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/48/commits/f68999f738160a6df414b100959bccef95d07bf0
- https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/48/commits/a456e484734df310930e3655afc935caebfe64a9 (fix needed in addition to above commit)

Adds a new ``tools/preprocess_dataset_mpi.py`` script:
- uses HuggingFace datasets as the source to build (.bin and .idx) input files for megatron
- uses MPI to distribute work via ``mpi4py`` to support multiple nodes
- ``--split`` option to name the HF dataset split name, defaults to ``train``
- ``--columns`` option to specify dataset feature (column) names to process from each row
- ``--shuffle`` option to randomly shuffle data samples
- ``--seed`` for random number generator on shuffle operations
- ``--count`` option to limit the number of selected samples, e.g. ``--count 10000`` to use 10k samples
- ``--mpi4py`` option to instruct script to use ``mpi4py`` instead of ``torch.distributed``
- ``--torch-backend`` option to select between ``gloo/mpi``
- ``--local_rank`` to support ``torch.distributed.launch`` when using ``torch.distributed``
- ``--log-interval`` to specify seconds between progress messages or 0 to disable

Assuming srun has been configured to launch MPI jobs, one can run this script with something like:
```
srun -n 320 -N 8 python preprocess_dataset_mpi.py \
       --input openwebtext \
       --output-prefix openwebtext-bert \
       --vocab bert-large-uncased-vocab.txt \
       --dataset-impl mmap \
       --tokenizer-type BertWordPieceLowerCase \
       --split-sentences \
       --shuffle \
       --seed 100
```

The script can use MPI and ``mpi4py``.  It requires that a shared file system exists, like Lustre or GPFS, such that one process can read a file written by another process.  In particular, there may be problems on NFS due to client-side caching.

TODO:
- [x] The resulting merged file is different in size from a file written directly.  I need to identify the cause. --
The size discrepancy was in the index file, which is resolved with the doc_idx fix here https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/752e958cd1b9e9e8caa50f0336de7f096e1338fc/megatron/data/indexed_dataset.py#L574  With the above fix, I verified that both the ``.bin`` and ``.idx`` files are identical using ``cmp`` after disabling the data shuffle.  
- [x] I have not tested reading the resulting input files, so they may be totally bogus right now.  -- Resolved after verifying merged files from multiple ranks are identical to the files produced by a single process.
- [x] Add some more exception handling to prevent MPI deadlocks on problems. -- Resolved by surrounding per-rank I/O step with try/except block and an allreduce to check that all succeeded.  Avoids merge if anyone fails, but cleans up per-rank files regardless.
- [x] Support options for shuffling if desired, like enable/disable shuffle and define a random seed.  -- Resolved by adding ``--shuffle`` and ``--seed`` options in https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/48/commits/32fc48fe67dc60e303311fa2a1c800e5c80e7aba)
- [x] Use standard convention for setting rank/size in ``torch.distributed.init_process_group``
- [x] Catch exceptions to avoid MPI deadlocks, but re-raise exceptions where possible
- [x] Settle on ``HF_DATASETS_OFFLINE`` item

In my testing with 320 procs on 8 nodes, start up takes 2 minutes, it takes about 15 minutes for all processes to write their .bin/.idx file, and the merge takes 3 more minutes.  It processes the full ``openwebtext`` dataset in 20 minutes.
```
Opening dataset openwebtext
Dataset({
    features: ['text'],
    num_rows: 8013769
})
> building BertWordPieceLowerCase tokenizer ...
 > padded vocab (size: 30522) with 70 dummy tokens (new size: 30592)
Seconds to startup: 146.8052520751953
Vocab size: 30522
Output prefix: openwebtext-6-bert
> building BertWordPieceLowerCase tokenizer ...
 > padded vocab (size: 30522) with 70 dummy tokens (new size: 30592)
Seconds to tokenize: 912.1747498512268
Documents= 8013769 docs/sec= 8785.344037759238
Sentences= 307384162 sent/sec= 336979.46807904245
Bytes= 39386887788 bytes/sec= 43179103.34003862
Merging rank files ...
Merging file openwebtext-6-bert_text_sentence_0
<snip>
Seconds to merge: 169.25763988494873
Merged 320 files into openwebtext-6-bert
Bytes= 17425293230 bytes/sec= 102951295.0898091
Deleting rank files ...

real	20m51.461s
user	0m0.197s
sys	0m0.084s
```

The file system hosting the source dataset, the intermediate .bin/.idx files, and the final merged file is GPFS, which provides 120GB/s write bandwidth.