### PR TITLE
shuffle index list with numpy, scatter list, use file for large lists

### DIFF
--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -233,7 +233,7 @@ def scatterv_(args, invals, counts, outval, root=0):
         displs = np.cumsum(counts) - counts
         args.mpi_comm.Scatterv([invals, counts, displs, args.MPI.INT64_T], outval, root=root)
     else:
-    scatterlist = None
+        scatterlist = None
         if args.rank == root:
             scatterlist = list(torch.split(torch.from_numpy(invals), counts))
         outtensor = torch.from_numpy(outval)

--- a/tools/preprocess_dataset_mpi.py
+++ b/tools/preprocess_dataset_mpi.py
@@ -233,7 +233,7 @@ def scatterv_(args, invals, counts, outval, root=0):
         displs = np.cumsum(counts) - counts
         args.mpi_comm.Scatterv([invals, counts, displs, args.MPI.INT64_T], outval, root=root)
     else:
-        scatterlist = []
+    scatterlist = None
         if args.rank == root:
             scatterlist = list(torch.split(torch.from_numpy(invals), counts))
         outtensor = torch.from_numpy(outval)


### PR DESCRIPTION
This updates the index selection logic in a couple ways:
- switches from ``random.shuffle`` to ``numpy.random.shuffle`` (timed to be about 10x faster)
- replaces the broadcast with a scatter

The scatter is implemented in two ways.  The first uses a scatter collective.  The second writes the full list to a temporary file that is then read back by each process.

I suppose if the scatter collective seems to be reliable, the temporary file is not needed and could be dropped.  I've left it in there for now.

Update:
Decided to drop the scatter file to simplify the code.  I think the scatterv should be sufficient, and if not, it's easy to add the file method back.