### PR TITLE
fix: doc_idx offset when merging indexed dataset files

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -298,16 +298,16 @@ class IndexedDatasetBuilder(object):
         index = IndexedDataset(another_file)
         assert index.dtype == self.dtype
 
-        offset = len(self.sizes)
+        doc_offset = len(self.sizes)
 
         begin = self.data_offsets[-1]
-        for offset in index.data_offsets[1:]:
-            self.data_offsets.append(begin + offset)
+        for data_offset in index.data_offsets[1:]:
+            self.data_offsets.append(begin + data_offset)
         self.sizes.extend(index.sizes)
         begin = self.dim_offsets[-1]
         for dim_offset in index.dim_offsets[1:]:
             self.dim_offsets.append(begin + dim_offset)
-        self.doc_idx.extend( (offset + index.doc_idx)[1:] )
+        self.doc_idx.extend( (doc_offset + index.doc_idx)[1:] )
 
         with open(data_file_path(another_file), 'rb') as f:
             while True:


### PR DESCRIPTION
This fixes an issue when computing the document index offset value when merging cached ``IndexedDataset`` files.  The problem was that ``offset`` is overwritten in the ``data_offset`` loop before it is used to adjust the document index values.