### PR TITLE
[testing] fixes for pt-1.10

### DIFF
--- a/megatron/testing_utils.py
+++ b/megatron/testing_utils.py
@@ -207,6 +207,10 @@ def get_gpu_count():
     else:
         return 0
 
+def torch_assert_equal(actual, expected):
+    """ emulates the removed torch.testing.assert_equal """
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
 
 def get_tests_dir(append_path=None):
     """

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import functional as F
 
 from megatron.model.activations import liglu, geglu, reglu, swiglu
-from megatron.testing_utils import set_seed
+from megatron.testing_utils import set_seed, torch_assert_equal
 
 
 class TestActivations(unittest.TestCase):
@@ -27,16 +27,16 @@ class TestActivations(unittest.TestCase):
 
     def test_liglu(self):
         expected = self.x1 * self.x2
-        torch.testing.assert_close(liglu(self.x), expected, rtol=0.0, atol=0.0)
+        torch_assert_equal(liglu(self.x), expected)
 
     def test_geglu(self):
         expected = self.x1 * F.gelu(self.x2)
-        torch.testing.assert_close(geglu(self.x), expected, rtol=0.0, atol=0.0)
+        torch_assert_equal(geglu(self.x), expected)
 
     def test_reglu(self):
         expected = self.x1 * F.relu(self.x2)
-        torch.testing.assert_close(reglu(self.x), expected, rtol=0.0, atol=0.0)
+        torch_assert_equal(reglu(self.x), expected)
 
     def test_swiglu(self):
         expected = self.x1 * F.silu(self.x2)
-        torch.testing.assert_close(swiglu(self.x), expected, rtol=0.0, atol=0.0)
+        torch_assert_equal(swiglu(self.x), expected)

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -27,16 +27,16 @@ class TestActivations(unittest.TestCase):
 
     def test_liglu(self):
         expected = self.x1 * self.x2
-        torch.testing.assert_equal(liglu(self.x), expected)
+        torch.testing.assert_close(liglu(self.x), expected, rtol=0.0, atol=0.0)
 
     def test_geglu(self):
         expected = self.x1 * F.gelu(self.x2)
-        torch.testing.assert_equal(geglu(self.x), expected)
+        torch.testing.assert_close(geglu(self.x), expected, rtol=0.0, atol=0.0)
 
     def test_reglu(self):
         expected = self.x1 * F.relu(self.x2)
-        torch.testing.assert_equal(reglu(self.x), expected)
+        torch.testing.assert_close(reglu(self.x), expected, rtol=0.0, atol=0.0)
 
     def test_swiglu(self):
         expected = self.x1 * F.silu(self.x2)
-        torch.testing.assert_equal(swiglu(self.x), expected)
+        torch.testing.assert_close(swiglu(self.x), expected, rtol=0.0, atol=0.0)


### PR DESCRIPTION
pytorch-1.10-to-be dropped the non-public API `torch.testing.assert_equal`, see: https://pytorch.org/docs/stable/testing.html

So this is a follow up to: https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/47 to make the tests work with pt-nightly.

I used
```
torch.testing.assert_close(liglu(self.x), expected, rtol=0.0, atol=0.0)
```
to replace the function that was removed.

Perhaps we can add a wrapper for `torch_assert_equal` in `testing_utils.py` instead? 

@jaketae 