### PR TITLE
[WIP] [codecarbon] sorting out CC warnings + logger preamble

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -164,9 +164,14 @@ def _set_codecarbon_tracker(args):
     output_dir = args.codecarbon_dir
     output_file = f"emissions-{args.rank:03d}.csv"
     logger_preamble = f"r{args.rank:03d}"
-    log_level = "warning"
+    log_level = "error"
     country_iso_code = "FRA"
+
+    # CC was emitting all kinds of warnings about issues with measurements, so the following
+    # settings are supposed to help
     misfire_grace_time = 3
+    measure_power_secs = 60
+    max_instances = 3
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     _GLOBAL_CODECARBON_TRACKER = codecarbon.OfflineEmissionsTracker(
@@ -175,6 +180,8 @@ def _set_codecarbon_tracker(args):
         logger_preamble=logger_preamble,
         log_level=log_level,
         misfire_grace_time=misfire_grace_time,
+        measure_power_secs=measure_power_secs,
+        max_instances=max_instances,
         country_iso_code=country_iso_code,
     )
 

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -163,14 +163,18 @@ def _set_codecarbon_tracker(args):
 
     output_dir = args.codecarbon_dir
     output_file = f"emissions-{args.rank:03d}.csv"
+    logger_preamble = f"r{args.rank:03d}"
     log_level = "warning"
-    country_iso_code="FRA"
+    country_iso_code = "FRA"
+    misfire_grace_time = 3
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     _GLOBAL_CODECARBON_TRACKER = codecarbon.OfflineEmissionsTracker(
         output_dir=output_dir,
         output_file=output_file,
+        logger_preamble=logger_preamble,
         log_level=log_level,
+        misfire_grace_time=misfire_grace_time,
         country_iso_code=country_iso_code,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ torch
 transformers
 DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git@big-science
 # edit to a higher SHA or future release if needed
-codecarbon @ git+https://github.com/mlco2/codecarbon.git@03479b695a771c28df6b877a809f5af3eb9ef3b8
+codecarbon @ git+https://github.com/mlco2/codecarbon.git@e6c3863


### PR DESCRIPTION
Currently CC generates a ton of warnings at run time - and not measuring all of carbon! - this PR is trying possible workarounds proposed in https://github.com/mlco2/codecarbon/pull/241

So adding:

```
    # CC was emitting all kinds of warnings about issues with measurements, so the following
    # settings are supposed to help
    misfire_grace_time = 3
    measure_power_secs = 60
    max_instances = 3
```

Also added a logger preamble so that we could tell which rank the warning comes from.

- changed the hardwired SHA in requirements.txt to https://github.com/mlco2/codecarbon/commit/e6c3863acafc0d3482f0c8f6d23ab884662c4727 hoping for 2.0 release soon.