### PR TITLE
update merge_preprocessed_data to use distributed merge

### DIFF
--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -1038,18 +1038,22 @@ def gather_files_dist_check_impltype(filelist, distctx):
     raise UnreachableCode
 
 
-# Collectively merge files into a new output file specified in filemain.
-# Each rank contributes a distinct list of zero or more files in filelist,
-# and each rank directly merges its set of files into filemain.
-# It is allowed for the input files in filelist to only be readable from the calling process.
-# The output file in filemain should be in a location that is writable by all processes.
-#
-# NOTE: This uses parallel writes to a shared file to achieve high write bandwidth.
-# To do so, this implementation seeks beyond the end of the file to write at different
-# offsets from different processes via the seek() method on a python file handle.
-# The behavior of seek() is not well documented, but it seems to map to fseek()/lseek(),
-# and it works as desired on POSIX-compliant file systems like Lustre and GPFS.
 def gather_files_dist(filemain, filelist, distctx):
+    """Collectively merge files into a new output file specified in filemain.
+
+    Each rank contributes a distinct list of zero or more files in filelist,
+    and each rank directly merges its set of files into filemain.
+    It is allowed for the input files in filelist to only be readable from the calling process.
+    In particular, the input files specified by the calling process may be in storage
+    that only the calling process can access, like /dev/shm or a node-local SSD.
+    The output file in filemain should be in a location that is writable by all processes.
+    
+    NOTE: This uses parallel writes to a shared file to achieve high write bandwidth.
+    To do so, this implementation seeks beyond the end of the file to write at different
+    offsets from different processes via the seek() method on a python file handle.
+    The behavior of seek() is not well documented, but it seems to map to fseek()/lseek(),
+    and it works as desired on POSIX-compliant file systems like Lustre and GPFS."""
+
     # Check that at least one input file is listed
     filecount = distctx.sum(len(filelist))
     assert filecount > 0, "All ranks have no input files to merge"
@@ -1068,6 +1072,26 @@ def gather_files_dist(filemain, filelist, distctx):
 
 
 def get_start_end(count, rank, numranks):
+    """Return (start, end) index values for calling rank to evenly divide count items among numranks.
+
+    Example usage:
+        start, end = get_start_end(len(itemlist), distctx.rank, distctx.numranks)
+        sublist = itemlist[start:end]
+
+    Parameters
+    ----------
+    count : int
+        Total number of items to be divided
+    rank : int
+        Rank of the calling process, within range of [0, numranks)
+    numranks : int
+        Number of ranks by which to divide count items
+
+    Returns
+    ----------
+    (start, end) : tuple(int)
+        Start and end index values that define the [start, end) range for rank
+    """
     num, remainder = divmod(count, numranks)
     if rank < remainder:
         start = (num + 1) * rank
@@ -1078,14 +1102,24 @@ def get_start_end(count, rank, numranks):
     return start, end
 
 
-# Given a global list of files in filelist, and a set of processed defined
-# by the distributed environment in distctx, collectively merge files into
-# a new output specified in filemain.
 def merge_files_dist(filemain, filelist, distctx):
+    """Merge list of indexed datasets into a single indexed dataset named in filemain.
+
+    Given a list of indexed datasets in filelist, and the set of processes defined
+    by the distributed environment in distctx, collectively merge files into
+    a new, single output indexed dataset named in filemain.  This overwrites filemain
+    if it already exists.  It does not delete the input datasets in filelist.  The input
+    parameters filemain and filelist must be identical on all calling processes,
+    and all processes in distctx must call this method collectively.
+    It requires that all ranks be able to read any file in filelist, and all
+    ranks must be able to write to the single output file named in filemain."""
+
     # TODO: if file sizes vary significantly, it might be better to consider
     # file size when splitting the list to different ranks.
 
     # evenly divide list of files among ranks
     start, end = get_start_end(len(filelist), distctx.rank, distctx.numranks)
     sublist = filelist[start:end]
+
+    # delegate merge to gather implementation
     return gather_files_dist(filemain, sublist, distctx)

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -1065,3 +1065,27 @@ def gather_files_dist(filemain, filelist, distctx):
         gather_files_dist_idx_cached(filemain, filelist, distctx)
     elif indexstr == "mmap":
         gather_files_dist_idx_mmap(filemain, filelist, distctx)
+
+
+def get_start_end(count, rank, numranks):
+    num, remainder = divmod(count, numranks)
+    if rank < remainder:
+        start = (num + 1) * rank
+        end = start + num + 1
+    else:
+        start = (num + 1) * remainder + num * (rank - remainder)
+        end = start + num
+    return start, end
+
+
+# Given a global list of files in filelist, and a set of processed defined
+# by the distributed environment in distctx, collectively merge files into
+# a new output specified in filemain.
+def merge_files_dist(filemain, filelist, distctx):
+    # TODO: if file sizes vary significantly, it might be better to consider
+    # file size when splitting the list to different ranks.
+
+    # evenly divide list of files among ranks
+    start, end = get_start_end(len(filelist), distctx.rank, distctx.numranks)
+    sublist = filelist[start:end]
+    return gather_files_dist(filemain, sublist, distctx)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -95,6 +95,119 @@ class MegDSTestPreprocessing(TestCasePlus):
             self.assertTrue(Path(tgt_path).exists(), )
             self.assertTrue(filecmp.cmp(tgt_path, ref_path, shallow=False))
 
+    def preprocess_partitioned_dataset(self, output_dir, dsetname, splitname, linelimit, numparts):
+        """Preprocess a dataset as a whole and in shards to prepare environment for merge test.
+
+        Load specified HF dataset using given split and record limit.
+        Write the dataset to a jsonl file and preprocess.
+        Also split dataset into numparts contiguous shards, write each shard to its own jsonl, and preprocess each.
+        Return path to the full dataset and a list of paths for each shard."""
+
+        src_dir = self.src_dir
+        data_dir = f"{self.data_dir}/gpt2"
+
+        # preproces_data_dist requires one to have already downloaded the input HF dataset.
+        # We do that by running this script before the test.
+        dset = download_hf_dataset(dsetname)[splitname]
+
+        # limit the test to use the first linelimit entries to be faster
+        dset = dset.select(range(linelimit))
+
+        # write jsonl file of full dataset
+        json_ds = f"{output_dir}/ds-full.jsonl"
+        dset.to_json(json_ds)
+
+        # process full jsonl into indexed dataset file
+        ds_full = f"{output_dir}/ds-full"
+        cmd = f"""
+                python {src_dir}/tools/preprocess_data.py
+                    --input {json_ds}
+                    --output-prefix {ds_full}
+                    --dataset-impl mmap
+                    --tokenizer-type GPT2BPETokenizer
+                    --merge-file {data_dir}/gpt2-tiny-merges.txt
+                    --vocab {data_dir}/gpt2-tiny-vocab.json
+                    --append-eod
+                """.split()
+        ds_full += '_text_document'
+
+        # keep for quick debug
+        # print(" ".join([f"\nPYTHONPATH={self.src_dir_str}"] +cmd)); die
+        execute_subprocess_async(cmd, env=self.get_env())
+
+        # write each part to its own json file
+        ds_parts = []
+        for i in range(numparts):
+            json_part = f"{output_dir}/ds-part-{i}.jsonl"
+            dset.shard(numparts, i, contiguous=True).to_json(json_part)
+
+            ds_part = f"{output_dir}/ds-part-{i}"
+            ds_parts.append(ds_part + '_text_document')
+            cmd = f"""
+                    python {src_dir}/tools/preprocess_data.py
+                        --input {json_part}
+                        --output-prefix {ds_part}
+                        --dataset-impl mmap
+                        --tokenizer-type GPT2BPETokenizer
+                        --merge-file {data_dir}/gpt2-tiny-merges.txt
+                        --vocab {data_dir}/gpt2-tiny-vocab.json
+                        --append-eod
+                    """.split()
+
+            # keep for quick debug
+            # print(" ".join([f"\nPYTHONPATH={self.src_dir_str}"] +cmd)); die
+            execute_subprocess_async(cmd, env=self.get_env())
+
+        return ds_full, ds_parts
+
+    def test_merge_serial(self):
+        """Check that serial merge of partial dataset files produces the same file as the full dataset."""
+        src_dir = self.src_dir
+        output_dir = self.get_auto_remove_tmp_dir()  # "./xxx", after=False)
+
+        # process full dataset, and process the full dataset as 3 contiguous chunks
+        ds_full, ds_parts = self.preprocess_partitioned_dataset(output_dir, 'stas/openwebtext-10k', 'train', 100, 3)
+
+        # merge the part files into a single indexed dataset
+        ds_merged = f"{output_dir}/ds-merged"
+        cmd = f"""
+                python {src_dir}/tools/merge_preprocessed_data.py
+                    --datasets {" ".join(ds_parts)}
+                    --output-prefix {ds_merged}
+                """.split()
+
+        # keep for quick debug
+        # print(" ".join([f"\nPYTHONPATH={self.src_dir_str}"] +cmd)); die
+        execute_subprocess_async(cmd, env=self.get_env())
+
+        # the full dataset and the merged dataset should be identical
+        self.compare_meg_data_files(ds_full, ds_merged)
+
+    def test_merge_distributed(self):
+        """Check that serial merge of partial dataset files produces the same file as the full dataset."""
+        src_dir = self.src_dir
+        output_dir = self.get_auto_remove_tmp_dir()  # "./xxx", after=False)
+
+        # process full dataset, and process the full dataset as 3 contiguous chunks
+        ds_full, ds_parts = self.preprocess_partitioned_dataset(output_dir, 'stas/openwebtext-10k', 'train', 100, 3)
+
+        # merge the part files into a single indexed dataset
+        ds_merged = f"{output_dir}/ds-merged"
+        cmd = f"""
+                python -m torch.distributed.launch --nproc_per_node 6 {src_dir}/tools/merge_preprocessed_data.py
+                    --merge distributed
+                    --datasets {" ".join(ds_parts)}
+                    --output-prefix {ds_merged}
+                    --torch-backend gloo
+                """.split()
+
+        # keep for quick debug
+        # print(" ".join([f"\nPYTHONPATH={self.src_dir_str}"] +cmd)); die
+        execute_subprocess_async(cmd, env=self.get_env())
+
+        # the full dataset and the merged dataset should be identical
+        self.compare_meg_data_files(ds_full, ds_merged)
+
     def test_process_data_microsoft(self):
         """We want to be stable to Microsoft version."""
         src_dir = self.src_dir

--- a/tools/merge_preprocessed_data.py
+++ b/tools/merge_preprocessed_data.py
@@ -39,11 +39,6 @@ To operate in distributed mode:
       --output-prefix meg-gpt2_oscar_text_document
 """
 
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             os.path.pardir)))
-
 import argparse
 import time
 

--- a/tools/merge_preprocessed_data.py
+++ b/tools/merge_preprocessed_data.py
@@ -72,6 +72,7 @@ def get_args():
     # initialize distributed environment if distributed merge requested
     if args.merge == 'distributed':
         if args.torch_backend is None:
+            print_rank_0("Distributed merge using --torch-backend=gloo as default")
             args.torch_backend = 'gloo'
         args.distctx = DistData(backend=args.torch_backend)
 

--- a/tools/merge_preprocessed_data.py
+++ b/tools/merge_preprocessed_data.py
@@ -1,8 +1,15 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             os.path.pardir)))
+
 import argparse
 import time
 
+from megatron import print_rank_0
 from megatron.data import indexed_dataset
-from megatron.data.indexed_dataset import infer_dataset_impl, MMapIndexedDataset, data_file_path, index_file_path
+from megatron.data.indexed_dataset import infer_dataset_impl, MMapIndexedDataset, data_file_path, index_file_path, merge_files_dist
+from megatron.data.distdata import DistData
 
 
 def get_args():
@@ -15,7 +22,21 @@ def get_args():
     group.add_argument('--output-prefix', type=str, required=True,
                        help='Path to binary output file without suffix')
 
-    return parser.parse_args()
+    group = parser.add_argument_group(title='runtime')
+    group.add_argument('--merge', type=str, default='parallel', choices = ['parallel', 'serial'],
+                       help='Whether to use a distributed parallal merge or a non-distributed serial merge.')
+    group.add_argument('--torch-backend', type=str, default='gloo', choices = ['gloo', 'mpi'],
+                       help='Select torch.distributed backend.')
+    group.add_argument('--local_rank', type=int, default=None,
+                       help='Local rank of calling process on its node (from torch.distributed.launch).')
+
+    args = parser.parse_args()
+
+    # initialize distributed environment if parallel merge requested
+    if args.merge == 'parallel':
+        args.distctx = DistData(backend=args.torch_backend)
+
+    return args
 
 def main():
     """
@@ -24,33 +45,35 @@ def main():
     args = get_args()
     startup_start = time.time()
 
-    print("Merging", args.datasets)
+    print_rank_0(f"Merging {args.datasets}")
+    print_rank_0(f"Output prefix: {args.output_prefix}")
 
-    # We use the first dataset to infer the dataset implementation common to all datasets.
-    dataset_impl = infer_dataset_impl(args.datasets[0])
-    assert dataset_impl is not None
+    if args.merge == 'parallel':
+        merge_files_dist(args.output_prefix, args.datasets, args.distctx)
+    else:
+        # We use the first dataset to infer the dataset implementation common to all datasets.
+        dataset_impl = infer_dataset_impl(args.datasets[0])
+        assert dataset_impl is not None
 
-    first_dataset = indexed_dataset.make_dataset(args.datasets[0], dataset_impl)
-    # We use the first dataset to infer the dtype common to all datasets.
-    dtype = first_dataset.dtype if isinstance(first_dataset, MMapIndexedDataset) else None
+        first_dataset = indexed_dataset.make_dataset(args.datasets[0], dataset_impl)
+        # We use the first dataset to infer the dtype common to all datasets.
+        dtype = first_dataset.dtype if isinstance(first_dataset, MMapIndexedDataset) else None
 
-    print(f"Output prefix: {args.output_prefix}")
+        output_filename = args.output_prefix
+        output_bin_file = data_file_path(output_filename)
+        output_idx_file = index_file_path(output_filename)
+        builder = indexed_dataset.make_builder(output_bin_file,
+                                               impl=dataset_impl,
+                                               dtype=dtype)
+        for dataset in args.datasets:
+            builder.merge_file_(dataset)
 
-    output_filename = args.output_prefix
-    output_bin_file = data_file_path(output_filename)
-    output_idx_file = index_file_path(output_filename)
-    builder = indexed_dataset.make_builder(output_bin_file,
-                                           impl=dataset_impl,
-                                           dtype=dtype)
-    for dataset in args.datasets:
-        builder.merge_file_(dataset)
-
-    builder.finalize(output_idx_file)
+        builder.finalize(output_idx_file)
 
     startup_end = time.time()
-    print("Time to merge:", startup_end - startup_start)
+    print_rank_0(f"Time to merge: {startup_end - startup_start")
 
-    print(f"Merged {len(args.datasets)} datasets to {args.output_prefix}")
+    print_rank_0(f"Merged {len(args.datasets)} datasets to {args.output_prefix}")
 
 if __name__ == "__main__":
     main()

--- a/tools/merge_preprocessed_data.py
+++ b/tools/merge_preprocessed_data.py
@@ -7,13 +7,14 @@ collectively merge datasets into a single file.
 
 The serial mode is simpler to use.
 
-The parallel mode can improve performance when larging many or
-large datasets.  The distributed mode requires one to write
-the output dataset to a POSIX-complaint file system that supports
-shared parallel access to the file as different processes write
-to different regions of the output file simultaneously.
+Provides that the file system permits it, the parallel mode
+can improve performance when merging many dataset files.
+The distributed mode requires one to write the output dataset to
+a POSIX-complaint file system that supports shared parallel
+access to the file as different processes write to different
+regions of the output file simultaneously.
 
-To operate in serial mode:
+To run in serial mode:
 
   python tools/merge_preprocessed_data.py \
     --datasets \
@@ -22,7 +23,7 @@ To operate in serial mode:
       meg-gpt2-oscar-en-500-p3_text_document \
     --output-prefix meg-gpt2_oscar_text_document
 
-To operate in distributed mode:
+To run in distributed mode:
 
   MASTER_ADDR="localhost"
   MASTER_PORT=12345

--- a/tools/merge_preprocessed_data.py
+++ b/tools/merge_preprocessed_data.py
@@ -106,7 +106,7 @@ def main():
         # Ensure that all datasets use the same implementaton.
         for ds in args.datasets:
             ds_impl = infer_dataset_impl(ds)
-            assert ds_impl == dataset_impl, f"Dataset type {ds_impl} in file {ds} does not match type {dataset_impl} from file {args.datasets[0]}"
+            assert ds_impl == dataset_impl, f"Dataset type '{ds_impl}' in file '{ds}' does not match type '{dataset_impl}' from file '{args.datasets[0]}'"
 
         # We use the first dataset to infer the dtype common to all datasets.
         first_dataset = indexed_dataset.make_dataset(args.datasets[0], dataset_impl)
@@ -124,7 +124,7 @@ def main():
         builder.finalize(output_idx_file)
 
     startup_end = time.time()
-    print_rank_0(f"Time to merge: {startup_end - startup_start")
+    print_rank_0(f"Time to merge: {startup_end - startup_start}")
     print_rank_0(f"Merged {len(args.datasets)} datasets to {args.output_prefix}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This extends the ``merge_preprocessed_data.py`` script to optionally use a parallel merge.  It changes that script to assume a distributed launch if given ``--merge distributed``.