### PR TITLE
WIP: set torch.distributed variables from srun and jsrun launchers

### DIFF
--- a/megatron/data/distdata.py
+++ b/megatron/data/distdata.py
@@ -18,16 +18,12 @@ class DistData(object):
             os.environ["RANK"] = os.environ['SLURM_PROCID']
         if 'SLURM_NPROCS' in os.environ:
             os.environ["WORLD_SIZE"] = os.environ['SLURM_NPROCS']
-        if 'SLURM_LOCALID' in os.environ:
-            os.environ["LOCAL_RANK"] = os.environ['SLURM_LOCALID']
 
         # for launching with IBM LSF jsrun
         if 'OMPI_COMM_WORLD_RANK' in os.environ:
             os.environ["RANK"] = os.environ['OMPI_COMM_WORLD_RANK']
         if 'OMPI_COMM_WORLD_SIZE' in os.environ:
             os.environ["WORLD_SIZE"] = os.environ['OMPI_COMM_WORLD_SIZE']
-        if 'OMPI_COMM_WORLD_LOCAL_RANK' in os.environ:
-            os.environ["LOCAL_RANK"] = os.environ['OMPI_COMM_WORLD_LOCAL_RANK']
 
         dist.init_process_group(backend, init_method="env://")
 

--- a/megatron/data/distdata.py
+++ b/megatron/data/distdata.py
@@ -13,17 +13,17 @@ class DistData(object):
     def __init__(self, backend='gloo'):
         assert backend in ['gloo', 'mpi'], f"torch.distributed backend '{backend}' is not supported, valid options are 'gloo' or 'mpi'"
 
-        # for launching with SLURM srun
-        if 'SLURM_PROCID' in os.environ:
-            os.environ["RANK"] = os.environ['SLURM_PROCID']
-        if 'SLURM_NPROCS' in os.environ:
-            os.environ["WORLD_SIZE"] = os.environ['SLURM_NPROCS']
+        # if not already defined, set RANK and WORLD_SIZE based on launcher env vars
+        if 'RANK' not in os.environ:
+            # for launching with SLURM srun
+            if 'SLURM_PROCID' in os.environ:
+                os.environ["RANK"] = os.environ['SLURM_PROCID']
+                os.environ["WORLD_SIZE"] = os.environ['SLURM_NPROCS']
 
-        # for launching with IBM LSF jsrun
-        if 'OMPI_COMM_WORLD_RANK' in os.environ:
-            os.environ["RANK"] = os.environ['OMPI_COMM_WORLD_RANK']
-        if 'OMPI_COMM_WORLD_SIZE' in os.environ:
-            os.environ["WORLD_SIZE"] = os.environ['OMPI_COMM_WORLD_SIZE']
+            # for launching with IBM LSF jsrun
+            if 'OMPI_COMM_WORLD_RANK' in os.environ:
+                os.environ["RANK"] = os.environ['OMPI_COMM_WORLD_RANK']
+                os.environ["WORLD_SIZE"] = os.environ['OMPI_COMM_WORLD_SIZE']
 
         dist.init_process_group(backend, init_method="env://")
 

--- a/megatron/data/distdata.py
+++ b/megatron/data/distdata.py
@@ -13,6 +13,22 @@ class DistData(object):
     def __init__(self, backend='gloo'):
         assert backend in ['gloo', 'mpi'], f"torch.distributed backend '{backend}' is not supported, valid options are 'gloo' or 'mpi'"
 
+        # for launching with SLURM srun
+        if 'SLURM_PROCID' in os.environ:
+            os.environ["RANK"] = os.environ['SLURM_PROCID']
+        if 'SLURM_NPROCS' in os.environ:
+            os.environ["WORLD_SIZE"] = os.environ['SLURM_NPROCS']
+        if 'SLURM_LOCALID' in os.environ:
+            os.environ["LOCAL_RANK"] = os.environ['SLURM_LOCALID']
+
+        # for launching with IBM LSF jsrun
+        if 'OMPI_COMM_WORLD_RANK' in os.environ:
+            os.environ["RANK"] = os.environ['OMPI_COMM_WORLD_RANK']
+        if 'OMPI_COMM_WORLD_SIZE' in os.environ:
+            os.environ["WORLD_SIZE"] = os.environ['OMPI_COMM_WORLD_SIZE']
+        if 'OMPI_COMM_WORLD_LOCAL_RANK' in os.environ:
+            os.environ["LOCAL_RANK"] = os.environ['OMPI_COMM_WORLD_LOCAL_RANK']
+
         dist.init_process_group(backend, init_method="env://")
 
         # lookup our process rank and the group size


### PR DESCRIPTION
This is another PR just to kick around some ideas.

On machines that have SLURM or a launcher like IBM's ``jsrun``, it's pretty easy to get a ``torch.distributed`` program to extract its rank, size, and local_rank values from those system job launchers.  Basically, one needs to read a few environment variables that those launchers set for each process.

Launching 40 procs per node in a SLURM allocation using ``torch.distributed.launch`` requires something like:
```
MASTER_ADDR=$(scontrol show hostnames | head -n1)
MASTER_PORT=12345
LAUNCHER="python -u -m torch.distributed.launch \
    --nproc_per_node 40 \
    --nnodes $SLURM_JOB_NUM_NODES \
    --master_addr $MASTER_ADDR \
    --master_port $MASTER_PORT \
    "
srun bash -c '$LAUNCHER --node_rank $SLURM_PROCID distprog.py'
```

With changes like the one in this PR, things simplify to:
```
export MASTER_ADDR=$(scontrol show hostnames | head -n1)
export MASTER_PORT=12345
srun --ntasks-per-node 40 python distprog.py
```

For that matter, I suppose the following command might work without any changes to the code:
```
export MASTER_ADDR=$(scontrol show hostnames | head -n1)
export MASTER_PORT=12345
srun --ntasks-per-node 40 bash -c 'RANK=$SLURM_PROCID WORLD_SIZE=$SLURM_NPROCS python distprog.py'
```

I think pytorch lightning abstracts some of these ideas, so this might be reinventing the wheel.