### PR TITLE
add `nltk` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ torch
 six
 regex
 numpy
+nltk
 transformers
 # git+https://github.com/microsoft/DeepSpeed.git@big-science
 # edit to a higher SHA or future release if needed


### PR DESCRIPTION
On a new host the test suite failed needed  `nltk` -  adding it to `requirements.txt`