### PR TITLE
[requirements] fix format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ six
 tensorboard
 torch
 transformers
-git+https://github.com/microsoft/DeepSpeed.git@big-science
+DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git@big-science
 # edit to a higher SHA or future release if needed
-git+git://github.com/mlco2/codecarbon.git@03479b695a771c28df6b877a809f5af3eb9ef3b8
+codecarbon @ git+https://github.com/mlco2/codecarbon.git@03479b695a771c28df6b877a809f5af3eb9ef3b8


### PR DESCRIPTION
as `setup.py` pulls this file into `install_requires` - we have to support both formats - that of `setup.py` and that of `pip -r requirements.txt`, so this PR makes it possible.

Thanks to SO thread: https://stackoverflow.com/questions/32688688/how-to-write-setup-py-to-include-a-git-repository-as-a-dependency