### PR TITLE
check whether python3-config is available

### DIFF
--- a/megatron/data/Makefile
+++ b/megatron/data/Makefile
@@ -1,3 +1,10 @@
+
+PYTHON3CONFIG := $(shell command -v python3-config 2> /dev/null)
+
+ifndef PYTHON3CONFIG
+    $(error "python3-config is not available. Please install it. It may be in a python-dev or another package")
+endif
+
 CXXFLAGS += -O3 -Wall -shared -std=c++11 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell python3 -m pybind11 --includes)
 LIBNAME = helpers


### PR DESCRIPTION
Addressing https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/96 this PR adds an assertion in `Makefile` if `python3-config` is not available.