### PR TITLE
ALiBi Implementation

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -312,7 +312,7 @@ def _add_network_size_args(parser):
     group.add_argument('--position-embedding-type', type=lambda x: PositionEmbeddingType[x],
                        choices=list(PositionEmbeddingType),
                        default=PositionEmbeddingType.absolute,
-                       help='Define position embedding type ("absolute" | "rotary"). "absolute" by default.'
+                       help='Define position embedding type ("absolute" | "rotary" | "alibi"). "absolute" by default.'
                        )
     group.add_argument('--glu-activation', type=str,
                        choices=megatron.model.glu_activations.GLU_ACTIVATIONS.keys(),

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -222,7 +222,7 @@ def parse_args(extra_args_provider=None, defaults={},
         assert args.encoder_seq_length is not None
         args.seq_length = args.encoder_seq_length
 
-    if args.position_embedding_type == PositionEmbeddingType.absolute:
+    if args.position_embedding_type == PositionEmbeddingType.absolute or args.position_embedding_type == PositionEmbeddingType.alibi:
         assert args.max_position_embeddings is not None
         if args.seq_length is not None:
             assert args.max_position_embeddings >= args.seq_length

--- a/megatron/enums.py
+++ b/megatron/enums.py
@@ -30,3 +30,4 @@ class AttnMaskType(enum.Enum):
 class PositionEmbeddingType(enum.Enum):
     rotary = 1
     absolute = 2
+    alibi = 3

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -304,7 +304,7 @@ class ParallelAttention(MegatronModule):
             matmul_result,
             query_layer.transpose(0, 1),   # [b * np, sq, hn]
             key_layer.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
-            beta=0.0, alpha=(1.0/self.norm_factor))
+            beta=0.0 if alibi is None else 1.0, alpha=(1.0/self.norm_factor))
 
         # change view to [b, np, sq, sk]
         attention_scores = matmul_result.view(*output_size)

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -687,7 +687,7 @@ class ParallelTransformer(MegatronModule):
         if args.position_embedding_type == PositionEmbeddingType.alibi:
             self.alibi = self._build_alibi_tensor(args.seq_length, args.num_attention_heads, args.micro_batch_size).to(torch.cuda.current_device())
             if args.params_dtype == torch.float16:
-                self.alibi = self.alibi.half()
+                self.alibi = self.alibi.to(torch.bfloat16)
         else:
             self.alibi = None
 
@@ -794,4 +794,3 @@ class ParallelTransformer(MegatronModule):
             output = [output, presents]
 
         return output
-

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -615,7 +615,7 @@ class ParallelTransformer(MegatronModule):
                                                                    :n - closest_power_of_2]
         slopes = torch.Tensor(get_slopes(num_attention_heads))
         alibi = slopes.unsqueeze(1).unsqueeze(1) * torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(num_attention_heads, -1, -1)
-        alibi = alibi.view(num_attention_heads, 1, max_seq_len).repeat(batch_size, 1, 1)
+        alibi = alibi.repeat(batch_size, 1, 1)
         return alibi
 
     def __init__(self, init_method, output_layer_init_method,

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -687,6 +687,8 @@ class ParallelTransformer(MegatronModule):
         if args.position_embedding_type == PositionEmbeddingType.alibi:
             self.alibi = self._build_alibi_tensor(args.seq_length, args.num_attention_heads, args.micro_batch_size).to(torch.cuda.current_device())
             if args.params_dtype == torch.float16:
+                self.alibi = self.alibi.to(torch.float16)
+            elif args.params_dtype == torch.bfloat16:
                 self.alibi = self.alibi.to(torch.bfloat16)
         else:
             self.alibi = None


### PR DESCRIPTION
I've implemented ALiBi efficiently, by just modifying the matmul_result matrix in transformer.py 

On my hardware, with the pretrain_gpt.py example, ALiBi runs just as fast as sinusoidal and uses 20MB of extra memory (that is 0.2% of the total memory usage). 

I think this implementation could be made even more efficient by modifying the mask instead of matmul_result, but this would require modifying the cuda code in scaled_upper_triang_masked_softmax and I don't have that knowledge.

