### PR TITLE
simplify the CI trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,6 @@ on:
   push:
     branches:
       - "*"
-    paths:
-      - "megatron/**"
-      - "tests/**"
-      - ".github/**"
-      - "tools/**"
-      - "*.py"
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Run all tests
 # enable to manually trigger the tests
 #on:  workflow_dispatch
 on:
-  push:
-    branches:
+  pull_request_target:
+    paths:
       - "*"
 
 jobs:


### PR DESCRIPTION
It seems that PRs coming from forks don't get to access the aws secrets and the whole thing fails, so trying to use `pull_request_target` suggested here:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

Thanks to @philschmid for the suggestion