### PR TITLE
[testing] ensure no lock file is dropped

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -65,6 +65,11 @@ class MegDSTestTraining(TestCasePlus):
     def setUp(self):
         super().setUp()
 
+        # at times magatron fails to build kernels and doesn't remove the lock file, which makes
+        # subsequent runs hang - so make sure there is no lock when starting the testing
+        meg_lock_file_path = self.repo_root_dir_str + "/megatron/fused_kernels/build/lock"
+        os.unlink(meg_lock_file_path)
+
 
     def test_training_all(self):
         # all in one test

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -68,7 +68,8 @@ class MegDSTestTraining(TestCasePlus):
         # at times magatron fails to build kernels and doesn't remove the lock file, which makes
         # subsequent runs hang - so make sure there is no lock when starting the testing
         meg_lock_file_path = self.repo_root_dir_str + "/megatron/fused_kernels/build/lock"
-        os.unlink(meg_lock_file_path)
+        if os.path.exists(meg_lock_file_path):
+            os.unlink(meg_lock_file_path)
 
 
     def test_training_all(self):


### PR DESCRIPTION
At times magatron fails to build kernels and doesn't remove the lock file, which makes subsequent runs hang - so make sure there is no lock when starting the testing