### PR TITLE
Save tokenizer in conversion script

### DIFF
--- a/tools/convert_checkpoint/deepspeed_to_megatron.py
+++ b/tools/convert_checkpoint/deepspeed_to_megatron.py
@@ -25,6 +25,12 @@ def parse_arguments():
     parser.add_argument('--target_tp', default=1, type=int, help='Target TP degree')
     parser.add_argument('--target_pp', default=1, type=int, help='Target PP degree')
     parser.add_argument('--for_release', action='store_true', help='Convert for release purpose, reset some (progress) counters.')
+    parser.add_argument(
+        "--tokenizer_type", default="GPT2BPETokenizer", type=str, help="Tokenizer type"
+    )
+    parser.add_argument(
+        "--tokenizer_name_or_path", default="", type=str, help="Name or path to pretrained tokenizer"
+    )
     args = parser.parse_args()
     print(f'args = {args}')
     return args

--- a/tools/convert_checkpoint/deepspeed_to_transformers.py
+++ b/tools/convert_checkpoint/deepspeed_to_transformers.py
@@ -10,17 +10,22 @@ from deepspeed_to_megatron import _create_rank_checkpoint, parse_arguments
 # the import was tested to work with this version
 # https://github.com/huggingface/transformers/commit/0af901e83 if it diverges we may consider
 # copying that version here instead
-from transformers.models.megatron_gpt2.convert_megatron_gpt2_checkpoint import convert_megatron_checkpoint
-from transformers import GPT2Config
+from transformers.models.megatron_gpt2.convert_megatron_gpt2_checkpoint import (
+    convert_megatron_checkpoint,
+)
+from transformers import GPT2Config, AutoTokenizer
+
 
 def main():
-
     # this first part comes mainly from deepspeed_to_megatron.main
     args = parse_arguments()
-    print(f'Converting DeepSpeed checkpoint in {args.input_folder} to HF Transformers checkpoint in {args.output_folder}')
+    print(
+        f"Converting DeepSpeed checkpoint in {args.input_folder} to HF Transformers checkpoint in {args.output_folder}"
+    )
 
-    ds_checkpoint = DeepSpeedCheckpoint(args.input_folder, args.target_tp, args.target_pp)
-    iteration = ds_checkpoint.get_iteration()
+    ds_checkpoint = DeepSpeedCheckpoint(
+        args.input_folder, args.target_tp, args.target_pp
+    )
     input_state_dict = _create_rank_checkpoint(ds_checkpoint, 0, 0, args.for_release)
 
     # the 2nd part comes from transformers.models.megatron_gpt2.convert_megatron_gpt2_checkpoint.main
@@ -59,7 +64,7 @@ def main():
     os.makedirs(basename, exist_ok=True)
 
     # Print the structure of converted state dict.
-    #if args.print_checkpoint_structure:
+    # if args.print_checkpoint_structure:
     #    recursive_print(None, output_state_dict)
 
     # Store the config to file.
@@ -76,7 +81,17 @@ def main():
     print(f'Saving checkpoint to "{output_checkpoint_file}"')
     torch.save(output_state_dict, output_checkpoint_file)
 
-    print("Now add tokenizer files and upload to the hub")
+    # Save tokenizer based on args
+    print("Now add tokenizer files")
+    tokenizer_type = args.tokenizer_type
+    if tokenizer_type == "GPT2BPETokenizer":
+        tokenizer_model_name = "gpt2"
+    elif tokenizer_type == "PretrainedFromHF":
+        tokenizer_model_name = args.tokenizer_name_or_path
+    else:
+        raise ValueError(f"Unrecognized tokenizer_type {tokenizer_type}")
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_model_name)
+    tokenizer.save_pretrained(basename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements the following:

- Accept `tokenizer_type`  and `tokenizer_name_or_path` arguments
- Save pretrained tokenizers alongside the the converted model

