### PR TITLE
Configure code style formatters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: test
+.PHONY: test style
 
-# Run tests for the library
+check_dirs := tests tools/convert_checkpoint
 
+# this target tests for the library
 test:
 	pytest tests
+
+# this target runs checks on all files and potentially modifies some of them
+style:
+	black $(check_dirs)
+	isort $(check_dirs)

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 
 check_dirs := tests tools/convert_checkpoint
 
-# this target tests for the library
-test:
+help: ## this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+test: ## run tests
 	pytest tests
 
-# this target runs checks on all files and potentially modifies some of them
-style:
+style: ## checks for code style and applies formatting
 	black $(check_dirs)
 	isort $(check_dirs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 119
+target-version = ['py35']

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ transformers
 DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git
 # at some point when it starts working freeze with ether min version or sha using the syntax codecarbon.git@deadbeaf 
 codecarbon @ git+https://github.com/mlco2/codecarbon.git
+# versions from HF transformers
+black==21.4b0
+isort>=5.5.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+[isort]
+default_section = FIRSTPARTY
+ensure_newline_before_comments = True
+force_grid_wrap = 0
+include_trailing_comma = True
+known_first_party = megatron
+known_third_party =
+    apex
+    codecarbon
+    datasets
+    deepspeed
+    git
+    nltk
+    numpy
+    pytest
+    tensorboard
+    torch
+    tqdm
+    transformers
+
+line_length = 119
+lines_after_imports = 2
+multi_line_output = 3
+use_parentheses = True


### PR DESCRIPTION
This PR fixes #129 by implementing the following:

- Add `black` and `isort` to dependencies
- Add formatting `Make` command
- Add `pyproject.toml` and `setup.cfg` for consistent formatting options