### PR TITLE
Only trigger CI on `.py` file changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: Run all tests
 on:
   pull_request_target:
     paths:
-      - "*"
+      - "**.py"
 
 jobs:
 


### PR DESCRIPTION
Currently, the CI seems to run on every PR. While this is a safe way to ensure that all tests pass, a more sensible rule might be to trigger the pipeline only when material changes are made to the code base, i.e., when a `.py` file is modified or pushed.