### PR TITLE
[codecarbon] switch to master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ tensorboard
 torch
 transformers
 DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git
-# edit to a higher SHA or future release if needed
-codecarbon @ git+https://github.com/mlco2/codecarbon.git@e6c3863
+# at some point when it starts working freeze with ether min version or sha using the syntax codecarbon.git@deadbeaf 
+codecarbon @ git+https://github.com/mlco2/codecarbon.git


### PR DESCRIPTION
The frozen codecarbon SHA in requirements is breaking the test suite, trying with master.
https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/134/checks?check_run_id=3853541452
