### PR TITLE
Bump minimum version for torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pybind11
 regex
 six
 tensorboard
-torch
+torch>=1.7
 transformers
 DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git
 # versions from HF transformers


### PR DESCRIPTION
In prefixLM we rely on passing bool tensors via nccl. The ability to pass bool tensors in pytorch was available from 1.7 onwards.

Pytorch issue: https://github.com/pytorch/pytorch/issues/24137
Discussion with Deepspeed team: https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/107#discussion_r714321658