### PR TITLE
[tests] fix requirements

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -59,7 +59,6 @@ def get_3d_dimensions():
     return pp_size, tp_size, dp_size
 
 
-@require_bnb
 @require_deepspeed
 @require_torch_gpu
 class MegDSTestTraining(TestCasePlus):


### PR DESCRIPTION
`bitsandbytes` shouldn't be a requirement unless its specific test is running