### PR TITLE
don't save latest_checkpointed_iteration.txt w/ deepspeed

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -176,7 +176,7 @@ def save_checkpoint(iteration, model, optimizer, lr_scheduler):
         iteration, args.save))
 
     # And update the latest iteration
-    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+    if not args.deepspeed and not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         tracker_filename = get_checkpoint_tracker_filename(args.save)
         with open(tracker_filename, 'w') as f:
             f.write(str(iteration))


### PR DESCRIPTION
deepspeed saves its own `latest` file and it's very confusing when one needs to manually adjust the latest since currently we also get `latest_checkpointed_iteration.txt` from meg-lm saved.

This PR ensures that under DS only `latest` file is created.