### PR TITLE
[logging] remove useless log line

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -330,11 +330,14 @@ class Timers:
     def log(self, names, normalizer=1.0, reset=True):
         """Log a group of timers."""
         assert normalizer > 0.0
-        string = 'time (ms)'
+        string = ''
         for name in names:
             elapsed_time = self.timers[name].elapsed(
                 reset=reset) * 1000.0 / normalizer
             string += ' | {}: {:.2f}'.format(name, elapsed_time)
+        if not len(string):
+            return
+        string = 'time (ms)' + string
         if torch.distributed.is_initialized():
             if torch.distributed.get_rank() == (
                     torch.distributed.get_world_size() - 1):


### PR DESCRIPTION
Currently there is a strange "time (ms)" between each log line printed, so we get:
```
 iteration      110/     129 | consumed samples:          300 | consumed tokens:       307200 | elapsed time per iteration (ms): 164.1 | learning rate: 0.000E+00 | global batch size:     6 | lm loss: 1.064812E+01 | loss scale: 4096.0 | grad norm: 3448.131 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms)
 iteration      120/     129 | consumed samples:          360 | consumed tokens:       368640 | elapsed time per iteration (ms): 141.9 | learning rate: 0.000E+00 | global batch size:     6 | lm loss: 1.065025E+01 | loss scale: 4096.0 | grad norm: 3545.428 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
time (ms)
```

this PR removes it so now we get 2x vertical space with just:
```
 iteration      110/     129 | consumed samples:          300 | consumed tokens:       307200 | elapsed time per iteration (ms): 164.1 | learning rate: 0.000E+00 | global batch size:     6 | lm loss: 1.064812E+01 | loss scale: 4096.0 | grad norm: 3448.131 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
 iteration      120/     129 | consumed samples:          360 | consumed tokens:       368640 | elapsed time per iteration (ms): 141.9 | learning rate: 0.000E+00 | global batch size:     6 | lm loss: 1.065025E+01 | loss scale: 4096.0 | grad norm: 3545.428 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 |
```