### PR TITLE
[PrefixLM] Fix aggregation in DP for prefixLM

### DIFF
--- a/pretrain_prefix_lm.py
+++ b/pretrain_prefix_lm.py
@@ -150,11 +150,13 @@ def get_batch_pipe(data):
 
 def loss_func(loss_mask, output_tensor):
     losses = output_tensor.float()
-    loss_mask = loss_mask.view(-1).float()
-    loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
+    loss_mask = loss_mask.view(-1)
+    loss_weight = loss_mask.float().sum()
+
+    loss = torch.sum(losses.view(-1)[loss_mask]) / loss_weight
 
     # Reduce loss for logging.
-    averaged_loss = average_losses_across_data_parallel_group([loss])
+    averaged_loss = average_losses_across_data_parallel_group([loss], loss_weight=loss_weight)
 
     return loss, {'lm loss': averaged_loss[0]}
 


### PR DESCRIPTION
PrefixLM currently training mechanism has high variance in terms of tokens it is trained on (For each sample we uniformly choose the number of tokens we train on). Not all samples within a batch have the same amount of tokens. 