### PR TITLE
[PrefixLM] Figuring out why prefix lm is doing poorly on short context

### DIFF
--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -178,7 +178,7 @@ def get_cross_entropy(is_prefix: bool):
             expected_number_of_tokens /= 2
 
         loss_mask = loss_mask.view(-1)
-        loss = torch.sum(losses.view(-1)[loss_mask]) / expected_number_of_tokens
+        loss = torch.sum(losses.view(-1) * loss_mask) / expected_number_of_tokens
         return loss
     return CrossEntropy
 

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -159,15 +159,28 @@ class GPTModel(MegatronModule):
         self.language_model.load_state_dict(state_dict, strict=strict)
 
 
-def CrossEntropy(output, labels):
-    labels, loss_mask = labels[0], labels[1]
+def get_cross_entropy(is_prefix: bool):
+    def CrossEntropy(output, labels):
+        labels, loss_mask = labels[0], labels[1]
 
-    args = get_args()
+        args = get_args()
 
-    losses = mpu.vocab_parallel_cross_entropy(output.contiguous().float(), labels)
-    loss_mask = loss_mask.view(-1)
-    loss = torch.sum(losses.view(-1)[loss_mask]) / loss_mask.shape[0]
-    return loss
+        losses = mpu.vocab_parallel_cross_entropy(output.contiguous().float(), labels)
+        micro_batch_size, sequence_length = loss_mask.shape
+
+        # HACK: This is useful when we obtain loss masks that are microbatch dependent. Consequently, if we want to
+        #   preserve the notion that all tokens have the same impact on the loss, we can only normalise using a
+        #   microbatch independent value.
+        #   Here we still use `sequence_length`, that's batch size dependent, in order to be backwards compatible with
+        #   current experiment on vanilla gpt.
+        expected_number_of_tokens = micro_batch_size * sequence_length
+        if is_prefix:
+            expected_number_of_tokens /= 2
+
+        loss_mask = loss_mask.view(-1)
+        loss = torch.sum(losses.view(-1)[loss_mask]) / expected_number_of_tokens
+        return loss
+    return CrossEntropy
 
 
 class GPTModelPipe(PipelineModule,MegatronModule):
@@ -277,7 +290,7 @@ class GPTModelPipe(PipelineModule,MegatronModule):
                                              num_dp=mpu.get_data_parallel_world_size())
 
         super().__init__(layers=self.specs,
-                         loss_fn=CrossEntropy,
+                         loss_fn=get_cross_entropy(is_prefix=prefix_lm),
                          topology=topo,
                          activation_checkpoint_interval=interval,
                          partition_method='type:transformer')

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -168,13 +168,15 @@ def get_cross_entropy(is_prefix: bool):
         losses = mpu.vocab_parallel_cross_entropy(output.contiguous().float(), labels)
 
         if is_prefix:
-            # HACK: This is useful when we obtain loss masks that are microbatch dependent. Consequently, if we want to
-            #   preserve the notion that all tokens have the same impact on the loss, we can only normalise using a
-            #   microbatch independent value.
-            #   Here we still use `sequence_length`, that's batch size dependent, in order to be backwards compatible with
-            #   current experiment on vanilla gpt.
             micro_batch_size, sequence_length = loss_mask.shape
-            expected_number_of_tokens = micro_batch_size * sequence_length / 2
+            expected_number_of_tokens = micro_batch_size * sequence_length
+            if args.loss_on_targets_only:
+                # HACK: This is useful when we obtain loss masks that are microbatch dependent. Consequently, if we want to
+                #   preserve the notion that all tokens have the same impact on the loss, we can only normalise using a
+                #   microbatch independent value.
+                #   Here we still use `sequence_length`, that's batch size dependent, in order to be backwards compatible with
+                #   current experiment on vanilla gpt.
+                expected_number_of_tokens /= 2
         else:
             expected_number_of_tokens = loss_mask.sum()
 

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -166,7 +166,7 @@ def CrossEntropy(output, labels):
 
     losses = mpu.vocab_parallel_cross_entropy(output.contiguous().float(), labels)
     loss_mask = loss_mask.view(-1)
-    loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
+    loss = torch.sum(losses.view(-1)[loss_mask]) / loss_mask.shape[0]
     return loss
 
 

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -168,8 +168,6 @@ def get_ltor_masks_and_position_ids(
     # Extract batch size and sequence length.
     micro_batch_size, seq_length = data.size()
 
-    assert prefix_indices is None or loss_on_targets_only is True, "Prefix lm requires loss on targets only"
-
     # Attention mask (lower triangular).
     if reset_attention_mask or prefix_indices is not None:
         att_mask_batch = micro_batch_size

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -282,8 +282,8 @@ class MegDSTestTraining(TestCasePlus):
         if variation == "glu":
             self.assertIn("Using GLU activation: GELU", cs.out)
 
-
-    def test_training_prefix_lm_all(self):
+    @parameterized.expand([(True, ), (False, )])
+    def test_training_prefix_lm_all(self, loss_on_targets_only):
         # all in one test
         src_dir = self.src_dir
         data_dir = f"{self.data_dir}/gpt2"
@@ -308,7 +308,7 @@ class MegDSTestTraining(TestCasePlus):
             --rampup-batch-size 2 2 {n_samples}
             --global-batch-size 16
             --train-samples {n_samples}
-            --loss-on-targets-only
+            {"--loss-on-targets-only" if loss_on_targets_only else ""}
 
             --optimizer adam
             --adam-beta1 0.9


### PR DESCRIPTION
What deepspeed does (I think):
 - sum microbatch losses across gradient_accumulations: https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/pipe/engine.py#L671-L673
 - average loss across DP: https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/pipe/engine.py#L525-L527

What Megatron-DS does:
 - averages all tokens trained on (selected via loss_masking) within microbatch (normalisation factor is the number of tokens trained on, `loss_mask.sum()`): https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/main/megatron/model/gpt_model.py#L167-L169
 
 The issue is we have a high variance of tokens we train on (`loss_mask.sum()`) in prefixlm in micro batches compared to batches. Therefore the value changes a lot and by normalising with this value we lose significant information. In order to better understand this, let us imagine two microbatches (of single samples):
 
| Microbatch id | Prefix  |  Suffix |
| - | - | - |
| 0 | t0 t1 t2 t3 t4 t5 t6 t7 t8 | t9 |
| 1 | t0 | t1 t2 t3 t4 t5 t6 t7 t8 t9 |

If you average the loss within the suffix, and then summing them together. The weight for the token t9 of MB0 is 9 times higher than then one for MB1. This means that since weights for microbatches are the same, then the model really has to make sure to get the easy samples right (ie the ones with smallest prediction AND bigger context).
 
 In order to change that, I think making the normalisation factor in Meg-DS independent of loss_mask would greatly help, since now all tokens are "equal" in terms of weight, and microbatches weight are directly dependent on the number of tokens we train on. (this code)
 
 We could also change the sampling strategy for prefix indices. Typically, weights should be like `probability -= np.arange(sequence_length, 0, -1)` where we bias it in order to have a lot more short context than long ones. cc @TevenLeScao as it was similar to an idea he had at some point.
 
 
**THIS SHOULD NOT BE MERGED AS IT CHANGES THE MODEL AND MIGHT BREAK OTHER TRAININGS**: This is just to see how one would "fix" the strong bias to long context.