### PR TITLE
[PrefixLM] Allow prefix lm to run with loss on target only false

### DIFF
--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -168,13 +168,15 @@ def get_cross_entropy(is_prefix: bool):
         losses = mpu.vocab_parallel_cross_entropy(output.contiguous().float(), labels)
 
         if is_prefix:
-            # HACK: This is useful when we obtain loss masks that are microbatch dependent. Consequently, if we want to
-            #   preserve the notion that all tokens have the same impact on the loss, we can only normalise using a
-            #   microbatch independent value.
-            #   Here we still use `sequence_length`, that's batch size dependent, in order to be backwards compatible with
-            #   current experiment on vanilla gpt.
             micro_batch_size, sequence_length = loss_mask.shape
-            expected_number_of_tokens = micro_batch_size * sequence_length / 2
+            expected_number_of_tokens = micro_batch_size * sequence_length
+            if args.loss_on_targets_only:
+                # HACK: This is useful when we obtain loss masks that are microbatch dependent. Consequently, if we want to
+                #   preserve the notion that all tokens have the same impact on the loss, we can only normalise using a
+                #   microbatch independent value.
+                #   Here we still use `sequence_length`, that's batch size dependent, in order to be backwards compatible with
+                #   current experiment on vanilla gpt.
+                expected_number_of_tokens /= 2
         else:
             expected_number_of_tokens = loss_mask.sum()
 

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -168,8 +168,6 @@ def get_ltor_masks_and_position_ids(
     # Extract batch size and sequence length.
     micro_batch_size, seq_length = data.size()
 
-    assert prefix_indices is None or loss_on_targets_only is True, "Prefix lm requires loss on targets only"
-
     # Attention mask (lower triangular).
     if reset_attention_mask or prefix_indices is not None:
         att_mask_batch = micro_batch_size

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -282,8 +282,8 @@ class MegDSTestTraining(TestCasePlus):
         if variation == "glu":
             self.assertIn("Using GLU activation: GELU", cs.out)
 
-
-    def test_training_prefix_lm_all(self):
+    @parameterized.expand([(True, ), (False, )])
+    def test_training_prefix_lm_all(self, loss_on_targets_only):
         # all in one test
         src_dir = self.src_dir
         data_dir = f"{self.data_dir}/gpt2"
@@ -308,7 +308,7 @@ class MegDSTestTraining(TestCasePlus):
             --rampup-batch-size 2 2 {n_samples}
             --global-batch-size 16
             --train-samples {n_samples}
-            --loss-on-targets-only
+            {"--loss-on-targets-only" if loss_on_targets_only else ""}
 
             --optimizer adam
             --adam-beta1 0.9


### PR DESCRIPTION
We want to start experimenting if we remove the loss mask.

Context: prefixlm trained on oscar performes poorly on shorter context.

The initial intuition was that this task would be too easy for the model as it know the future in the non causal region. However T5 author has shared that he ran it with this option. One of the intuition is that it regularises hidden states.

**Careful**: This is being merged on top of  https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/169 
