### PR TITLE
[BNB] integrate `StableEmbeding` into `VocabParallelEmbedding` logic

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -286,7 +286,6 @@ def parse_args(extra_args_provider=None, defaults={},
     if args.use_bnb_optimizer:
         try:
             import bitsandbytes as bnb
-            self.embedding_module = bnb.nn.StableEmbedding
         except ModuleNotFoundError:
             raise ModuleNotFoundError("Please install bitsandbytes from https://github.com/facebookresearch/bitsandbytes.")
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -283,6 +283,13 @@ def parse_args(extra_args_provider=None, defaults={},
     if args.glu_activation is not None and args.bias_gelu_fusion:
         raise ValueError("if glu-activation is used, please set --no-bias-gelu-fusion")
 
+    if args.use_bnb_optimizer:
+        try:
+            import bitsandbytes as bnb
+            self.embedding_module = bnb.nn.StableEmbedding
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Please install bitsandbytes from https://github.com/facebookresearch/bitsandbytes.")
+
     _print_args(args)
     return args
 

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -134,20 +134,10 @@ class Embedding(MegatronModule):
         self._word_embeddings_key = 'word_embeddings'
 
         # Position embedding (serial).
-        self.position_embedding_type = args.position_embedding_type
-        if args.use_bnb_optimizer:
-            try:
-                import bitsandbytes as bnb
-                self.embedding_module = bnb.nn.StableEmbedding
-            except ModuleNotFoundError:
-                print("Please install bitsandbytes following https://github.com/facebookresearch/bitsandbytes.")
-                raise Exception
-        else:
-            self.embedding_module = torch.nn.Embedding
         if self.position_embedding_type == PositionEmbeddingType.absolute:
             max_position_embeddings = args.max_position_embeddings
             assert max_position_embeddings is not None
-            self.position_embeddings = self.embedding_module(
+            self.position_embeddings = torch.nn.Embedding(
                 max_position_embeddings, self.hidden_size)
             self._position_embeddings_key = 'position_embeddings'
             # Initialize the position embeddings.
@@ -161,8 +151,8 @@ class Embedding(MegatronModule):
         # token types and add them as needed.
         self._tokentype_embeddings_key = 'tokentype_embeddings'
         if self.num_tokentypes > 0:
-            self.tokentype_embeddings = self.embedding_module(self.num_tokentypes,
-                                                              self.hidden_size)
+            self.tokentype_embeddings = torch.nn.Embedding(
+                self.num_tokentypes, self.hidden_size)
             # Initialize the token-type embeddings.
             self.init_method(self.tokentype_embeddings.weight)
         else:

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -134,6 +134,7 @@ class Embedding(MegatronModule):
         self._word_embeddings_key = 'word_embeddings'
 
         # Position embedding (serial).
+        self.position_embedding_type = args.position_embedding_type
         if self.position_embedding_type == PositionEmbeddingType.absolute:
             max_position_embeddings = args.max_position_embeddings
             assert max_position_embeddings is not None
@@ -172,8 +173,8 @@ class Embedding(MegatronModule):
             print('adding embedding for {} tokentypes'.format(num_tokentypes),
                   flush=True)
         self.num_tokentypes = num_tokentypes
-        self.tokentype_embeddings = self.embedding_module(num_tokentypes,
-                                                          self.hidden_size)
+        self.tokentype_embeddings = self.torch.nn.Embedding(num_tokentypes,
+                                                            self.hidden_size)
         # Initialize the token-type embeddings.
         args = get_args()
         self.init_method(self.tokentype_embeddings.weight)

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -148,7 +148,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         # Keep the input dimensions.
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
-        # Set the detauls for compatibility.
+        # Set the defaults for compatibility.
         self.padding_idx = None
         self.max_norm = None
         self.norm_type = 2.
@@ -156,7 +156,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         self.sparse = False
         self._weight = None
         self.tensor_model_parallel_size = get_tensor_model_parallel_world_size()
-        # Divide the weight matrix along the vocaburaly dimension.
+        # Divide the weight matrix along the vocabulary dimension.
         self.vocab_start_index, self.vocab_end_index = \
             VocabUtility.vocab_range_from_global_vocab_size(
                 self.num_embeddings, get_tensor_model_parallel_rank(),
@@ -190,7 +190,7 @@ class VocabParallelEmbedding(torch.nn.Module):
             masked_input[input_mask] = 0
         else:
             masked_input = input_
-            # Get the embeddings.
+        # Get the embeddings.
         output_parallel = F.embedding(masked_input, self.weight,
                                       self.padding_idx, self.max_norm,
                                       self.norm_type, self.scale_grad_by_freq,
@@ -223,7 +223,7 @@ class ColumnParallelLinear(torch.nn.Module):
                                      set to False. It returns the master weights
                                      used for initialization.
         skip_bias_add: This was added to enable performance optimations where bias
-                       can be fused with other elementwise operations. we skip 
+                       can be fused with other elementwise operations. we skip
                        adding bias but instead return it.
     """
 
@@ -261,7 +261,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 device=torch.cuda.current_device(), dtype=args.params_dtype))
             _initialize_affine_weight_gpu(self.weight, init_method,
                                           partition_dim=0, stride=stride)
-            
+
         if bias:
             if args.use_cpu_initialization:
                 self.bias = Parameter(torch.empty(
@@ -291,7 +291,7 @@ class ColumnParallelLinear(torch.nn.Module):
             # All-gather across the partitions.
             output = gather_from_tensor_model_parallel_region(output_parallel)
         else:
-            output = output_parallel 
+            output = output_parallel
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
@@ -322,7 +322,7 @@ class RowParallelLinear(torch.nn.Module):
                                      set to False. It returns the master weights
                                      used for initialization.
         skip_bias_add: This was added to enable performance optimations where bias
-                       can be fused with other elementwise operations. we skip 
+                       can be fused with other elementwise operations. we skip
                        adding bias but instead return it.
     """
 
@@ -394,4 +394,3 @@ class RowParallelLinear(torch.nn.Module):
             output = output_
             output_bias = self.bias
         return output, output_bias
-

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -57,12 +57,8 @@ def get_megatron_optimizer(model):
     param_groups = _get_params_for_weight_decay_optimization(model)
     if args.optimizer == 'adam':
         if args.use_bnb_optimizer:
-            try:
-                import bitsandbytes as bnb
-                adam_optimizer = bnb.optim.Adam8bit
-            except ModuleNotFoundError:
-                print("Please install bitsandbytes following https://github.com/facebookresearch/bitsandbytes.")
-                raise Exception
+            import bitsandbytes as bnb
+            adam_optimizer = bnb.optim.Adam8bit
         else:
             adam_optimizer = Adam
         optimizer = adam_optimizer(param_groups,


### PR DESCRIPTION
Merge `bnb.StableEmbedding`'s logic into the custom Megatron-LM's `Embedding`

- move the bnb library check to args
- undoes some changes from https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/144 - only word embedding should be touched for BNB, the rest should remain untouched
- implement `xavier_uniform_tensor_parallel_` - a custom version of `torch.nn.init.xavier_uniform_` - that correctly adjusts for the full embed dimension and applied to partitioned one.
- merge the rest of the logic - `GlobalOptimManager` and `norm` at the end of `forward`

Fixes #180