### PR TITLE
[test] `--partition-activations`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,12 @@ on:
 jobs:
 
 # GPU sizes and types that we could use:
-# g4dn.12xlarge  4x 16GB T4 (CC 7.5)
+# g4dn.12xlarge  4x 16GB T4 (CC 7.5) (low availability)
+# p3.8xlarge     4x 16GB V100 (CC 7.0) (very low availability)
+
+# Unfit:
+# g3.16xlarge    4x 8GB Tesla M60 (CC 5.2) (not supported by cuda-11)
 # p2.8xlarge     8x 12GB K80 (CC 3.7 not supported by cuda-11)
-# p3.8xlarge     4x 16GB V100 (very low availability)
-# g3.16xlarge    4x 8GB Tesla M60 (CC 5.2)
 
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
 # g4dn.12xlarge - 4x 12GB
 # p2.8xlarge - 4x 12GB
 # p3.8xlarge - 4x 16GB
+# g3.16xlarge - 4x
   start-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
@@ -38,7 +39,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p2.8xlarge
+          ec2-instance-type: g3.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-b7533b96 # us-east-1c
           aws-resource-tags: > # optional, requires additional permissions
@@ -55,7 +56,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p2.8xlarge
+          ec2-instance-type: g3.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-a396b2ad # us-east-1f
           aws-resource-tags: > # optional, requires additional permissions
@@ -71,7 +72,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p2.8xlarge
+          ec2-instance-type: g3.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-df0f6180 # us-east-1a
           aws-resource-tags: > # optional, requires additional permissions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
 # GPU sizes:
 # g4ad.16xlarge - 4x 8GB
 # g4dn.12xlarge - 4x 12GB
+# p2.8xlarge - 4x 12GB
 # p3.8xlarge - 4x 16GB
   start-runner:
     name: Start self-hosted EC2 runner
@@ -37,7 +38,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g4ad.16xlarge
+          ec2-instance-type: p2.8xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-b7533b96 # us-east-1c
           aws-resource-tags: > # optional, requires additional permissions
@@ -54,7 +55,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g4ad.16xlarge
+          ec2-instance-type: p2.8xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-a396b2ad # us-east-1f
           aws-resource-tags: > # optional, requires additional permissions
@@ -70,7 +71,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g4ad.16xlarge
+          ec2-instance-type: p2.8xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-df0f6180 # us-east-1a
           aws-resource-tags: > # optional, requires additional permissions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
 
-# GPU sizes:
-# g4ad.16xlarge - 4x 8GB
-# g4dn.12xlarge - 4x 12GB
-# p2.8xlarge - 4x 12GB
-# p3.8xlarge - 4x 16GB
-# g3.16xlarge - 4x
+# GPU sizes and types that we could use:
+# g4dn.12xlarge  4x 16GB T4 (CC 7.5)
+# p2.8xlarge     8x 12GB K80 (CC 3.7 not supported by cuda-11)
+# p3.8xlarge     4x 16GB V100 (very low availability)
+# g3.16xlarge    4x 8GB Tesla M60 (CC 5.2)
+
   start-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g3.16xlarge
+          ec2-instance-type: g4dn.12xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-b7533b96 # us-east-1c
           aws-resource-tags: > # optional, requires additional permissions
@@ -56,7 +56,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g3.16xlarge
+          ec2-instance-type: g4dn.12xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-a396b2ad # us-east-1f
           aws-resource-tags: > # optional, requires additional permissions
@@ -72,7 +72,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: g3.16xlarge
+          ec2-instance-type: g4dn.12xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-df0f6180 # us-east-1a
           aws-resource-tags: > # optional, requires additional permissions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
 
+# GPU sizes:
+# g4ad.16xlarge - 4x 8GB
+# g4dn.12xlarge - 4x 12GB
+# p3.8xlarge - 4x 16GB
   start-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
@@ -33,7 +37,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p3.8xlarge
+          ec2-instance-type: g4ad.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-b7533b96 # us-east-1c
           aws-resource-tags: > # optional, requires additional permissions
@@ -50,7 +54,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p3.8xlarge
+          ec2-instance-type: g4ad.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-a396b2ad # us-east-1f
           aws-resource-tags: > # optional, requires additional permissions
@@ -66,7 +70,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-04933c2edcc56a03a
-          ec2-instance-type: p3.8xlarge
+          ec2-instance-type: g4ad.16xlarge
           security-group-id: sg-f2a4e2fc
           subnet-id: subnet-df0f6180 # us-east-1a
           aws-resource-tags: > # optional, requires additional permissions

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -102,6 +102,7 @@ class MegDSTestTraining(TestCasePlus):
                 --eval-interval 10
                 --eval-iters 5
                 --checkpoint-activations
+                --partition-activations
                 --exit-interval {exit_interval}
 
                 --merge-file {data_dir}/gpt2-tiny-merges.txt

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -41,18 +41,22 @@ def get_launcher(num_gpus):
     return f"deepspeed --num_nodes 1 --num_gpus {num_gpus}".split()
 
 def get_3d_dimensions():
-    num_gpus = min(2, get_gpu_count())
+    num_gpus = get_gpu_count()
 
-    # XXX: if we had 8 gpus, could do dp_size too!
-    dp_size = 1
-
+    if num_gpus >= 8:
+        dp_size = 2
+        pp_size = 2
+        tp_size = 2
     if num_gpus >= 4:
+        dp_size = 1
         pp_size = 2
         tp_size = 2
     elif num_gpus >= 2:
+        dp_size = 1
         pp_size = 2
         tp_size = 1
     else:
+        dp_size = 1
         pp_size = 1
         tp_size = 1
 
@@ -78,6 +82,7 @@ class MegDSTestTraining(TestCasePlus):
 
         pp_size, tp_size, dp_size = get_3d_dimensions()
         num_gpus = pp_size * tp_size * dp_size
+        print(f"Using {num_gpus} GPUs")
 
         n_samples = 300 # about 56 iterations
         exit_interval = 20 # some samples in the first half and then some more in the 2nd half after resume


### PR DESCRIPTION
Test that we can use `--partition-activations` (which shards activations and uses less gpu memory!)

Update: it only works with TP=2 or PP=2 - not both. Fails with TP=2 and PP=2.

So won't merge until this is fixed on the Deepspeed side.

Issue to track: https://github.com/microsoft/DeepSpeed/issues/1538