### PR TITLE
add layernorm in Embedding

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -368,7 +368,7 @@ def _add_network_size_args(parser):
                        help='If set, use original BERT residula connection '
                        'ordering.')
     group.add_argument('--embed-layernorm', action='store_true',
-                       help='use layernorm for embedding")
+                       help='use layernorm for embedding')
     group.add_argument('--openai-gelu', action='store_true',
                        help='Use OpenAIs GeLU implementation. This option'
                        'should not be used unless for backward compatibility'

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -367,6 +367,8 @@ def _add_network_size_args(parser):
                        action='store_true',
                        help='If set, use original BERT residula connection '
                        'ordering.')
+    group.add_argument('--embed-layernorm', action='store_true',
+                       help='use layernorm for embedding")
     group.add_argument('--openai-gelu', action='store_true',
                        help='Use OpenAIs GeLU implementation. This option'
                        'should not be used unless for backward compatibility'

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -188,9 +188,10 @@ class VocabParallelEmbedding(torch.nn.Module):
         # Allocate weights and initialize.
         args = get_args()
 
-        if args.use_bnb_optimizer:
+        if args.use_bnb_optimizer or args.embed_layernorm:
             self.norm = torch.nn.LayerNorm(embedding_dim)
 
+        if args.use_bnb_optimizer:
             # for BNB we ignore the passed init_method and use torch.nn.init.xavier_uniform_
             # modified to calculate std on the unpartitioned embedding
             init_method = partial(xavier_uniform_tensor_parallel_, tp_degree=self.tensor_model_parallel_size)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -144,7 +144,7 @@ class MegDSTestTraining(TestCasePlus):
                 --lr-warmup-samples 5
                 --clip-grad 1.0
                 --weight-decay 1e-1
-                --embed_layernorm
+                --embed-layernorm
                 --fp16
 
                 --log-level debug

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -144,6 +144,7 @@ class MegDSTestTraining(TestCasePlus):
                 --lr-warmup-samples 5
                 --clip-grad 1.0
                 --weight-decay 1e-1
+                --embed_layernorm
                 --fp16
 
                 --log-level debug


### PR DESCRIPTION
Given that BNB's layernorm in `Embedding` is very likely to have a positive impact on training stability, add this feature so that we can use it w/o BNB.

To activate add `--embed_layernorm`

Ideally I'd have set it by default, but that would break any resuming training since it won't have the weights in the checkpoint.

@ibeltagy, @VictorSanh, @TevenLeScao 