### PR TITLE
[WIP] dealing with multi-process noise

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -89,7 +89,7 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
         else:
             if args.log_level_replica is not None:
                 set_verbosity(args.log_level_replica)
-                set_verbosity_ds(args.log_level)
+                set_verbosity_ds(args.log_level_replica)
         _set_random_seed(args.seed)
 
     args = get_args()

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -38,6 +38,9 @@ import deepspeed
 
 
 def git_ds_info():
+    if not args.deepspeed:
+        return
+
     from deepspeed.env_report import main as ds_report
     ds_report()
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -66,6 +66,13 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
         if args.rank == 0:
             print('> setting random seeds to {} ...'.format(args.seed))
 
+        def set_verbosity_ds(logging_level: str):
+            if not args.deepspeed:
+                return
+            from deepspeed.utils import logger as ds_logger
+            log_level = logging.log_levels[logging_level]
+            ds_logger.setLevel(log_level)
+
         def set_verbosity(logging_level: str):
             log_level = logging.log_levels[logging_level]
             logging.set_verbosity(log_level)
@@ -78,9 +85,11 @@ def initialize_megatron(extra_args_provider=None, args_defaults={},
         if args.rank == 0:
             if args.log_level is not None:
                 set_verbosity(args.log_level)
+                set_verbosity_ds(args.log_level)
         else:
             if args.log_level_replica is not None:
                 set_verbosity(args.log_level_replica)
+                set_verbosity_ds(args.log_level)
         _set_random_seed(args.seed)
 
     args = get_args()

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -38,6 +38,7 @@ import deepspeed
 
 
 def git_ds_info():
+    args = get_args()
     if not args.deepspeed:
         return
 

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -271,7 +271,9 @@ def get_parameters_in_billions(model, exclude_embeddings=False):
     if exclude_embeddings:
         approx_parameters_in_billions = sum([non_embedding_params(model_module) for model_module in model])
     else:
-        warnings.warn("Parameter count with the embeddings will be inaccurate with PP > 1, as the first and last stage hold several copies of the embeddings")
+        args = get_args()
+        if args.rank == 0:
+            warnings.warn("Parameter count with the embeddings will be inaccurate with PP > 1, as the first and last stage hold several copies of the embeddings")
         approx_parameters_in_billions = unique_param_count([p for model_module in model for p in model_module.parameters()])
 
     return approx_parameters_in_billions*gpus_per_model/(1e9)

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -31,7 +31,6 @@ from megatron.utils import average_losses_across_data_parallel_group
 import deepspeed
 from deepspeed.runtime.utils import see_memory_usage
 import os
-import subprocess
 
 
 def model_provider(pre_process=True, post_process=True):
@@ -236,34 +235,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
     return train_ds, valid_ds, test_ds
 
 
-def command_exists(cmd):
-    result = subprocess.Popen(f'type {cmd}', stdout=subprocess.PIPE, shell=True)
-    return result.wait() == 0
-
-
-def git_ds_info():
-    from deepspeed.env_report import main as ds_report
-    ds_report()
-
-    # Write out version/git info
-    git_hash_cmd = "git rev-parse --short HEAD"
-    git_branch_cmd = "git rev-parse --abbrev-ref HEAD"
-    if command_exists('git'):
-        try:
-            result = subprocess.check_output(git_hash_cmd, shell=True)
-            git_hash = result.decode('utf-8').strip()
-            result = subprocess.check_output(git_branch_cmd, shell=True)
-            git_branch = result.decode('utf-8').strip()
-        except subprocess.CalledProcessError:
-            git_hash = "unknown"
-            git_branch = "unknown"
-    else:
-        git_hash = "unknown"
-        git_branch = "unknown"
-    print(f'**** Git info for Megatron: git_hash={git_hash} git_branch={git_branch} ****')
-
-
 if __name__ == "__main__":
-    git_ds_info()
     pretrain(train_valid_test_datasets_provider, model_provider, forward_step,
              args_defaults={'tokenizer_type': 'GPT2BPETokenizer'})


### PR DESCRIPTION
The current state of the framework is very poor when it comes to logging. Tens of thousands of lines of logs are logged when the process starts.

Additionally when training crashes it's extremely difficult to find the actual error with hundreds of processes overwriting each other's logs making it close to impossible to decipher the errors.

This PR will gradually attempt to reduce the useless replicated noise to the bare minimum and figure out how to make the actual error found quickly on crash. 

Also one essential config for everybody to start using is:

```
    --log-level info \
    --log-level-replica error \
```
so that you get all the info on the first process, but replicas remain silent unless there is an issue.
