### PR TITLE
[TB] add throughput graphs

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -692,7 +692,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                                   samples_per_sec, args.iteration)
                 writer.add_scalar('iteration-time/samples per second per replica',
                                   samples_per_sec_per_replica, args.iteration)
-                writer.add_scalar('iteration-time/TFLOPs per gpu',
+                writer.add_scalar('iteration-time/TFLOPs per gpu (estimated)',
                                   tflops, args.iteration)
 
         log_string = ' iteration {:8d}/{:8d} |'.format(


### PR DESCRIPTION
This PR adds 2 new TB graphs:
1. `iteration-time/samples per second` - shows throughput for the whole ensemble
2. `iteration-time/samples per second per replica` - shows throughput per replica
3. TFLOPs - a derivation of (2) with a constant multiplier

Please let me know if this is agreeable, or whether you'd like to propose some changes

Here is the manually plotted version of (1) y: `samples per second`. x = iterations.

![tr8b-104B-emb-norm](https://user-images.githubusercontent.com/10676103/143666282-188f2789-d264-477b-8fea-482bb6d04a63.png)

So you'd know what to expect.

If `DP=1` the 2 graphs would be identical.

The 2nd one is handy when one needs to compare graphs that are run with a different DP degree. Especially if DP is changed from job to job in the same run.

The key insight here is you can see how with the BS size increase the pipeline becomes more efficient and thus the throughput increases.

Just want to make sure you all agree with this addition before merging this.

The third graph is TFLOPs per gpu - which is just (2) with a multiplier, which can change with Curriculum learning, but otherwise it should be a fixed multiplier.

I wasn't sure whether it's best to add these to the `iteration-time/` group or perhaps creating a new `throughput` group. They all report speed.

If we use a new `throughput` group, we can also log TFLOPs there. But the TFLOPs graph would be identical to (2) since it's just a constant multiplier.

Added (1) and (3) to the log as well (last 2 entries):
```
 iteration      120/     129 | consumed samples:          360 | consumed tokens:       368640 | 
elapsed time per iteration (ms): 102.5 | learning rate: 0.000E+00 | global batch size:     6 | 
lm loss: 1.064686E+01 | loss scale: 4096.0 | grad norm: 3213.737 | num zeros: 0.0 | 
number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 0.059 | TFLOPs: 24.21 |
 ```
Lots of thanks to @deepakn94 for helping me to sort this one out.

Fixes: https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/157

@VictorSanh, @TevenLeScao, @SaulLu, @thomasw21