### PR TITLE
Fix consumed_valid_samples counting for several valid dataloaders

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1075,7 +1075,8 @@ def build_train_valid_test_data_iterators(
             train_ds[0], args.consumed_train_samples)
 
         # We collapse None and empty list as both should mean we don't run validation
-        valid_dataloaders = [build_pretraining_data_loader(d, args.consumed_valid_samples)\
+        # args.consumed_valid_samples accumulates the sum of valid steps for every dataset, which are all equal
+        valid_dataloaders = [build_pretraining_data_loader(d, args.consumed_valid_samples // len(valid_ds))
                             for d in valid_ds] \
                             if valid_ds is not None else []
         # We collapse None and empty list as both should mean we don't run test


### PR DESCRIPTION
Currently, the valid dataloaders accumulate the number of valid steps elapsed together: a single `args.consumed_valid_samples` counter is incremented for every dataset. This is an issue as each valid data sampler takes `args.consumed_valid_samples` as the elapsed valid steps to compare with the size of the dataset: it quickly grows bigger, which [breaks the data sampler initialization](https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/main/megatron/data/data_samplers.py#L73).

As every validation dataset is evaluated on equally, this PR fixes that issue by passing the correct number of elapsed valid steps per valid dataset, which is an equal fraction of `args.consumed_valid_samples for each data sampler.