### PR TITLE
[sync] replay layer_norm_cuda_kernel.cu fixes

### DIFF
--- a/megatron/fused_kernels/layer_norm_cuda_kernel.cu
+++ b/megatron/fused_kernels/layer_norm_cuda_kernel.cu
@@ -21,7 +21,7 @@
 #include "ATen/ATen.h"
 #include "ATen/AccumulateType.h"
 #include "ATen/cuda/CUDAContext.h"
-#include <THC/THCDeviceUtils.cuh>
+#include "ATen/cuda/DeviceUtils.cuh"
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -329,6 +329,7 @@ void cuApplyLayerNorm(
       mean[i1] = mu;
       invvar[i1] = c_invvar;
     }
+    __syncthreads();
   }
 }
 
@@ -644,6 +645,8 @@ void cuComputeGradInput(
         k_grad_input[l] = static_cast<T>(f_grad_input);
       }
     }
+    // prevent race where buf is written again before reads are done
+    __syncthreads();
   }
 }
 


### PR DESCRIPTION
 Megatron-DeepSpeed fails to build with pt-nightly https://github.com/pytorch/pytorch/issues/69746

This has been fixed in Megatron-LM - so backporting the fix here:

```
git checkout -b sync-thc
git remote add other https://github.com/NVIDIA/Megatron-LM
git fetch other
git cherry-pick 75e521a0603467bf5ec78b2175f5ca3dd56e9872
git cherry-pick 4831071c900df5901570984c28b9f907892ff632
git cherry-pick f1295380cf06b0475165fbcbd89fbd88e9fee84c
git commit
git push
```
