### PR TITLE
[logging] synced print

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -774,7 +774,7 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
         tp_rank = mpu.get_tensor_model_parallel_rank()
         pp_rank = mpu.get_pipeline_model_parallel_rank()
         preamble = f"[{tp_rank:0>3d}-{pp_rank:0>3d}]"
-        print(f"{preamble} {get_parameters_in_billions(model):.4f}B / {get_parameters_in_billions(model, exclude_embeddings=True):.4f}B")
+        print(f"{preamble} {get_parameters_in_billions(model):.4f}B / {get_parameters_in_billions(model, exclude_embeddings=True):.4f}B", flush=True)
         torch.distributed.barrier()
     else:
         torch.distributed.barrier()


### PR DESCRIPTION
This PR is trying to fix interleaved prints, like:

```
[003-008] 103.3651B / 103.3651B
[002-030] 103.3651B / 103.3651B[001-030] 103.3651B / 103.3651B

[001-022] 103.3651B / 103.3651B
[001-021] 103.3651B / 103.3651B
[003-017] 103.3651B / 103.3651B
[001-015] 103.3651B / 103.3651B[003-015] 103.3651B / 103.3651B[002-015] 103.3651B / 103.3651B
```

these all should be one column, but as you can see some of the processes of the same machine end up interleaving with other processes.