### PR TITLE
fix tflops calculation

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -678,9 +678,9 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         # otherwise it will be 3, but for 200B model, activation check-pointing will always be on.
         #
         # here:
-        # model_size_in_B * 4 * 2 * seqlen * batch_size / (time_in_msec_per_interation * total_gpus)
+        # model_size_in_B * 4 * 2 * seqlen * batch_size / (time_in_msec_per_interation * total_gpus * 1e3)
         checkpoint_activations_factor = 4 if args.checkpoint_activations else 3
-        tflops = args.parameters_in_billions_no_embedding * checkpoint_activations_factor * 2 * seq_len * batch_size / (elapsed_time_per_iteration * args.world_size)
+        tflops = args.parameters_in_billions_no_embedding * checkpoint_activations_factor * 2 * seq_len * batch_size / (elapsed_time_per_iteration * args.world_size * 1e3)
 
         # only the last rank process has a non-None _GLOBAL_TENSORBOARD_WRITER
         if writer and is_last_rank():


### PR DESCRIPTION
This PR fixes TFLOPs calculation which was missing `/1e3` and was reporting GFLOPs instead.

Thank you for investigating, @bhavitvyamalik!

Fixes: https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/221
