### PR TITLE
implement missing --no-load-optim support for deepspeed path

### DIFF
--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -272,7 +272,8 @@ def load_checkpoint(model, optimizer, lr_scheduler, load_arg='load', strict=True
     load_dir = getattr(args, load_arg)
 
     if args.deepspeed:
-        loaded_dir, state_dict = model[0].load_checkpoint(load_dir)
+        load_optimizer_states = False if args.no_load_optim else True
+        loaded_dir, state_dict = model[0].load_checkpoint(load_dir, load_optimizer_states=load_optimizer_states)
         if loaded_dir is None:
             print_rank_0('WARNING: could not find the metadata file {} '.format(
                 load_dir))


### PR DESCRIPTION
it appears that `--no-load-optim` was being silently ignored with `--deepspeed`. This PR implements it.