### PR TITLE
fix tests

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -231,7 +231,7 @@ class MegDSTestTraining(TestCasePlus):
                 --train-samples {n_samples}
 
                 --lr-decay-samples 6
-                
+
                 --position-embedding-type alibi
             """.split()
 
@@ -322,6 +322,7 @@ class MegDSTestTraining(TestCasePlus):
         data_dir = f"{self.data_dir}/gpt2"
         output_dir = self.get_auto_remove_tmp_dir() # "./xxx", after=False)
         logs_dir = f"{output_dir}/logs"
+        Path(logs_dir).mkdir(parents=True, exist_ok=True)
 
         pp_size, tp_size, dp_size = get_3d_dimensions()
         num_gpus = pp_size * tp_size * dp_size
@@ -438,6 +439,7 @@ class MegDSTestTraining(TestCasePlus):
         data_dir = f"{self.data_dir}/gpt2"
         output_dir = self.get_auto_remove_tmp_dir() # "./xxx", after=False)
         logs_dir = f"{output_dir}/logs"
+        Path(logs_dir).mkdir(parents=True, exist_ok=True)
 
         pp_size, tp_size, dp_size = get_3d_dimensions()
         num_gpus = pp_size * tp_size * dp_size


### PR DESCRIPTION
This PR is fixing failing tests introduced by https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/218

```
FAILED tests/test_training.py::MegDSTestTraining::test_mode2_dataloading_0_gpt
FAILED tests/test_training.py::MegDSTestTraining::test_mode2_dataloading_1_prefix
FAILED tests/test_training.py::MegDSTestTraining::test_mode2_dataloading_2_no_eval
FAILED tests/test_training.py::MegDSTestTraining::test_training_prefix_lm_all_0
FAILED tests/test_training.py::MegDSTestTraining::test_training_prefix_lm_all_1
FAILED tests/test_training.py::MegDSTestTraining::test_training_prefix_lm_all_2
FAILED tests/test_training.py::MegDSTestTraining::test_training_prefix_lm_all_3
```