### PR TITLE
[TB] log restarts

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -339,6 +339,19 @@ def write_args_to_tensorboard():
                             global_step=args.iteration)
 
 
+def log_restart_to_tensorboard():
+    """
+    Log new start and world size - the key is to denote a restart, and use world_size as another
+    useful info which can help to track changes in resource allocation.
+    """
+    args = get_args()
+    writer = get_tensorboard_writer()
+    if writer:
+        # emulate a blip to avoid flatline
+        writer.add_scalar('iteration-time/world_size', args.world_size, args.iteration)
+        writer.add_scalar('iteration-time/world_size', 0, args.iteration+1)
+
+
 def _initialize_mem_buffs():
     """Initialize manually allocated static memory."""
     args = get_args()

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -42,7 +42,7 @@ from megatron.checkpointing import save_checkpoint
 from megatron.model.module import Float16Module
 from megatron.optimizer import get_megatron_optimizer
 from megatron.initialize import initialize_megatron
-from megatron.initialize import write_args_to_tensorboard
+from megatron.initialize import write_args_to_tensorboard, log_restart_to_tensorboard
 from megatron.learning_rates import AnnealingLR
 from megatron.model.distributed import DistributedDataParallel as LocalDDP
 from megatron.utils import check_adlr_autoresume_termination, get_parameters_in_billions
@@ -781,6 +781,7 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
 
     # Write args to tensorboard
     write_args_to_tensorboard()
+    log_restart_to_tensorboard()
 
     # Turn on training mode which enables dropout.
     for model_module in model:


### PR DESCRIPTION
As we have recently discovered there was a very subtle issue with [the optimizer that wasn't fully restored on resume](https://github.com/bigscience-workshop/bigscience/blob/master/train/tr8b-104B/chronicles.md#on-the-importance-of-saving-and-restoring-the-optimizer-step-counter). And it's possible that some spikes we have encountered were related to that. 

So I think it'd help to log resume events.

I'm thinking perhaps simply logging `world_size` once per run, which will also have a second use which will tell us if we switched to a higher or lower number of nodes and perhaps see some additional correlations there.

Since TB will end up creating a flat line and we won't see the restart events I came up with the following hack, where on restart it logs world_size, and then logs another step with 0, so we end up having nice spikes for each restart with the height of the spike also showing the world size for that run.

Here is an example of 3 restarts with a world_size=2 on my machine:

![snapshot_114](https://user-images.githubusercontent.com/10676103/150246973-59aa13b4-6ddc-49d9-a9cd-172c2915a114.png)

Perhaps TB has another way to flag sparse points and not making them disappear by drawing a line between them. Like it'd be nice to have some way of making those points extra fat or something... but I didn't find a way.

Feedback and suggestions for improvements are very welcome.

