### PR TITLE
enable new_style for add_scalar function for faster data format

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -147,6 +147,7 @@ def _set_tensorboard_writer(args):
             _GLOBAL_TENSORBOARD_WRITER = SummaryWriter(
                 log_dir=args.tensorboard_dir,
                 max_queue=args.tensorboard_queue_size)
+            # this is supposed to make the data load in TB faster
             _GLOBAL_TENSORBOARD_WRITER.add_scalar = functools.partial(
                 _GLOBAL_TENSORBOARD_WRITER.add_scalar, new_style=True
             )

--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -15,6 +15,7 @@
 
 """Megatron global variables."""
 
+import functools
 import os
 import sys
 import time
@@ -146,6 +147,9 @@ def _set_tensorboard_writer(args):
             _GLOBAL_TENSORBOARD_WRITER = SummaryWriter(
                 log_dir=args.tensorboard_dir,
                 max_queue=args.tensorboard_queue_size)
+            _GLOBAL_TENSORBOARD_WRITER.add_scalar = functools.partial(
+                _GLOBAL_TENSORBOARD_WRITER.add_scalar, new_style=True
+            )
         except ModuleNotFoundError:
             print('WARNING: TensorBoard writing requested but is not '
                   'available (are you using PyTorch 1.1.0 or later?), '


### PR DESCRIPTION
this closes #235 by override the original `add_scalar` with `functools.partial` and add `new_style=True` arg to `add_scalar`

@stas00 Could you have a look as I can't a preprocessed dataset?

Thanks