### PR TITLE
fix `add_scalar` for pt<1.9

### DIFF
--- a/megatron/global_vars.py
+++ b/megatron/global_vars.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 
+from packaging import version
 from pathlib import Path
 
 import torch
@@ -148,9 +149,10 @@ def _set_tensorboard_writer(args):
                 log_dir=args.tensorboard_dir,
                 max_queue=args.tensorboard_queue_size)
             # this is supposed to make the data load in TB faster
-            _GLOBAL_TENSORBOARD_WRITER.add_scalar = functools.partial(
-                _GLOBAL_TENSORBOARD_WRITER.add_scalar, new_style=True
-            )
+            if version.parse(torch.__version__) >= version.parse("1.9"):
+                _GLOBAL_TENSORBOARD_WRITER.add_scalar = functools.partial(
+                    _GLOBAL_TENSORBOARD_WRITER.add_scalar, new_style=True
+                )
         except ModuleNotFoundError:
             print('WARNING: TensorBoard writing requested but is not '
                   'available (are you using PyTorch 1.1.0 or later?), '


### PR DESCRIPTION
Fixes https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/237 for when pt<1.9
