### PR TITLE
Fix throughput unit

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -666,7 +666,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         seq_len = args.curriculum_seqlen if args.curriculum_learning else args.seq_length
 
         # throughput
-        samples_per_sec = batch_size / (elapsed_time_per_iteration * 1e3)
+        samples_per_sec = batch_size / elapsed_time_per_iteration
         samples_per_sec_per_replica = samples_per_sec / args.data_parallel_size
         tokens_per_sec = samples_per_sec * seq_len
         tokens_per_sec_per_replica = tokens_per_sec / args.data_parallel_size

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -708,8 +708,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             args.consumed_train_samples)
         log_string += ' consumed tokens: {:12d} |'.format(
             args.consumed_train_tokens)
-        log_string += ' elapsed time per iteration (ms): {:.1f} |'.format(
-            elapsed_time_per_iteration * 1000.0)
+        log_string += ' elapsed time per iteration (s): {:.2f} |'.format(
+            elapsed_time_per_iteration)
         log_string += ' learning rate: {:.3E} |'.format(learning_rate)
         log_string += ' global batch size: {:5d} |'.format(batch_size)
         for key in total_loss_dict:

--- a/tools/logs/rescale-logs.py
+++ b/tools/logs/rescale-logs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# This script fixes up BigScience log files by adjusting and fixing
+# units of logged values to be seconds instead of milliseconds.
+# It does the modification in-place (so make back ups!).
+#
+# Example:
+#
+# find . -name "*.out*" -print0 | xargs -0 -P 8 rescale-logs.py
+#
+# See also the discussion in
+# https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/236.
+#
+# This script is derived from https://stackoverflow.com/a/60080531/9201239
+# and https://gist.github.com/stas00/4cd1651d1c8f01196ea322c733bde46c.
+
+import os
+import re
+import sys
+
+LINE_START_RE = re.compile(' ?iteration')
+ELAPSED_TIME_RE = re.compile(r'elapsed time per iteration \(ms\): ([0-9.]+)')
+SAMPLES_PER_SEC_RE = re.compile('samples per second: ([0-9.]+)')
+
+
+def rescale_logs(log_file_path):
+    new_log_file_path = log_file_path + '.new'
+    with open(log_file_path, 'r') as log_file:
+        with open(new_log_file_path, 'w') as new_log_file:
+            for line in log_file.readlines():
+                if LINE_START_RE.match(line):
+                    match = ELAPSED_TIME_RE.search(line)
+                    if match:
+                        # Logged time is in ms, so convert the match.
+                        time_in_sec = float(match[1]) / 1000
+                        replacement = (
+                            f'elapsed time per iteration (s): '
+                            f'{time_in_sec:.2f}'
+                        )
+
+                        # We only need to replace once per line.
+                        line = ELAPSED_TIME_RE.sub(replacement, line, count=1)
+
+                    match = SAMPLES_PER_SEC_RE.search(line)
+                    if match:
+                        # Logged time is in ms, so convert the match.
+                        time_in_sec = float(match[1]) * 1000
+                        # As the values are already logged up to 3
+                        # numbers after the decimal point and we scale
+                        # by exactly that amount, we log them without
+                        # decimal point here in order to not seem more
+                        # exact than we are.
+                        replacement = f'samples per second: {time_in_sec:.0f}'
+
+                        # We only need to replace once per line.
+                        line = SAMPLES_PER_SEC_RE.sub(
+                            replacement,
+                            line,
+                            count=1,
+                        )
+
+                new_log_file.write(line)
+
+    os.rename(new_log_file_path, log_file_path)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f'{sys.argv[0]} <input file>',
+              file=sys.stderr)
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    rescale_logs(input_file)
+    print('Done')

--- a/tools/logs/tb-rename-events.py
+++ b/tools/logs/tb-rename-events.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# This script renames event names in TensorBoard log files.
+# It does the renaming in-place (so make back ups!).
+#
+# Example:
+#
+# find . -name "*.tfevents*" -exec tb-rename-events.py {} "iteration-time" "iteration-time/iteration-time" \;
+#
+# More than one old tag can be remapped to one new tag – use ";" as a separator:
+#
+# tb-rename-events.py events.out.tfevents.1 "training loss;validation loss" "loss"
+#
+# This script is derived from https://stackoverflow.com/a/60080531/9201239
+# and https://gist.github.com/stas00/4cd1651d1c8f01196ea322c733bde46c.
+
+import os
+import sys
+
+# Use this if you want to avoid using the GPU
+os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+import tensorflow as tf
+from tensorflow.core.util.event_pb2 import Event
+
+
+def rename_events(input_file, old_tags, new_tag):
+    new_file = input_file + '.new'
+    # Make a record writer
+    with tf.io.TFRecordWriter(new_file) as writer:
+        # Iterate event records
+        for rec in tf.data.TFRecordDataset([input_file]):
+            # Read event
+            ev = Event()
+            ev.MergeFromString(rec.numpy())
+            # Check if it is a summary
+            if ev.summary:
+                # Iterate summary values
+                for v in ev.summary.value:
+                    # Check if the tag should be renamed
+                    if v.tag in old_tags:
+                        # Rename with new tag name
+                        v.tag = new_tag
+            writer.write(ev.SerializeToString())
+    os.rename(new_file, input_file)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print(f'{sys.argv[0]} <input file> <old tags> <new tag>',
+              file=sys.stderr)
+        sys.exit(1)
+    input_file, old_tags, new_tag = sys.argv[1:]
+    old_tags = old_tags.split(';')
+    rename_events(input_file, old_tags, new_tag)
+    print('Done')

--- a/tools/logs/tb-rescale-scalars.py
+++ b/tools/logs/tb-rescale-scalars.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# This script rescales scalar values in TensorBoard log files.
+# It does the modification in-place (so make back ups!).
+#
+# Example:
+#
+# find . -name "*.tfevents*" -exec tb-rescale-scalars.py {} "iteration-time/samples per second" 1000 \;
+#
+# More than one old tag can be rescaled – use ";" as a separator:
+#
+# tb-rescale-scalars.py events.out.tfevents.1 "training loss;validation loss" 1e-2
+#
+# By default, BigScience GPT throughput values will be fixed up according to
+# https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/236,
+# i.e. the rescaling fixes values wrongly logged as "seconds" when they are
+# actually milliseconds.
+#
+# This script is derived from https://stackoverflow.com/a/60080531/9201239
+# and https://gist.github.com/stas00/4cd1651d1c8f01196ea322c733bde46c.
+
+import os
+import sys
+
+# Use this if you want to avoid using the GPU
+os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+import tensorflow as tf
+from tensorflow.core.util.event_pb2 import Event
+
+
+def rescale_scalars(input_file, tags, rescale_factor):
+    new_file = input_file + '.new'
+    # Make a record writer
+    with tf.io.TFRecordWriter(new_file) as writer:
+        # Iterate event records
+        for rec in tf.data.TFRecordDataset([input_file]):
+            # Read event
+            ev = Event()
+            ev.MergeFromString(rec.numpy())
+            # Check if it is a summary
+            if ev.summary:
+                # Iterate summary values
+                for v in ev.summary.value:
+                    # Check if the tag should be rescaled
+                    if v.tag in tags:
+                        v.simple_value *= rescale_factor
+            writer.write(ev.SerializeToString())
+    os.rename(new_file, input_file)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f'{sys.argv[0]} <input file> [<tags> [<rescale factor>]]',
+              file=sys.stderr)
+        sys.exit(1)
+
+    if len(sys.argv) < 3:
+        sys.argv.append(';'.join([
+            'iteration-time/samples per second',
+            'iteration-time/samples per second per replica',
+            'iteration-time/tokens per second',
+            'iteration-time/tokens per second per replica',
+        ]))
+    if len(sys.argv) < 4:
+        sys.argv.append('1000')
+
+    input_file, tags, rescale_factor = sys.argv[1:]
+    tags = tags.split(';')
+    rescale_factor = float(rescale_factor)
+    rescale_scalars(input_file, tags, rescale_factor)
+    print('Done')


### PR DESCRIPTION
Was in milliseconds, is now in seconds. Variable names and log strings
indicate the unit is supposed to be seconds.

To fix up old TensorBoard log files, see
https://gist.github.com/janEbert/e364da49d4757499a7cdd8e71ffaa9e8.

I can also include the script in the repository if desired – I followed @stas00's example of using a GitHub gist here.

Fix #236.