### PR TITLE
Add support for SentencePiece tokenisers

### DIFF
--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -364,7 +364,7 @@ class _SentencePieceTokenizer(AbstractTokenizer):
         return self.tokenizer.decoder
 
     def tokenize(self, text):
-        return self.tokenizer.encode(text)
+        return self.tokenizer.encode_as_ids(text)
 
     def detokenize(self, token_ids):
         return self.tokenizer.decode(token_ids)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ six
 tensorboard
 torch>=1.7
 transformers
+sentencepiece
 DeepSpeed @ git+https://github.com/microsoft/DeepSpeed.git
 # versions from HF transformers
 black==21.4b0


### PR DESCRIPTION
HF tokenisers currently do not support byte fallback; sentencepiece tokenisers trained with byte fallback lose this functionality once converted intto the HF format . Nicolas is looking into implementing this functionality in `tokenizers`, but this is a backup in case it doesn't work out in time.

Example:
```
hf_tokenizer = AutoTokenizer.from_pretrained('bigscience/oscar_13_languages_alpha_weight')
' '.join(hf_tokenizer.tokenize('換金方法としてはコイン商への売却の他、'))
```
`Output : '換 金 方法 と し <unk> ン 商 <unk> の <unk> 却 の 他 、'`

```
spm_tokenizer = SentencePieceTokenizer()
spm_tokenizer.load('bigscience_multilingual_model/alpha/ar-bn-ca-en-es-eu-fr-hi-id-pt-vi-ur-zh', 'bpe', 'ar-bn-ca-en-es-eu-fr-hi-id-pt-vi-ur-zh', str(1), 130000)
' '.join([spm_tokenizer.tokenizer.id_to_piece(id) for id in spm_tokenizer.encode('換金方法としてはコイン商への売却の他、')])
```
`Output : '▁ 換 金 方法 と し <0xE3> <0x81> <0xA6> <0xE3> <0x81> <0xAF> <0xE3> <0x82> <0xB3> <0xE3> <0x82> <0xA4> ン 商 <0xE3> <0x81> <0xB8> の <0xE5> <0xA3> <0xB2> 却 の 他 、'`