### PR TITLE
implement kill switch

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -397,6 +397,11 @@ def _add_network_size_args(parser):
                        help='GLU activations to use.'
                        )
 
+    group.add_argument('--kill-switch-path', type=str,
+                       help='path to look for a kill switch, which if found will automatically exit the program'
+                       )
+
+
     group.add_argument('--log-level', type=str, choices=list(log_levels.keys()),
                        help="Logger log level to use on the main process. Possible choices are the log levels as strings: 'debug', "
                        "'info', 'warning', 'error' and 'critical', plus a 'passive' level which doesn't set anything and lets the "

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -15,6 +15,7 @@
 
 """General utilities."""
 
+import os
 import sys
 import warnings
 from random import randint
@@ -383,3 +384,11 @@ def reweight_loss_mask_(loss_mask: torch.Tensor, tokens: torch.Tensor):
     weight_loss = torch.arange(seq_length, 0, -1, dtype=torch.float, device=loss_mask.device) / (seq_length + 1) * 2
     # in-place operation
     loss_mask *= weight_loss[None, :]
+
+
+def found_kill_switch():
+    args = get_args()
+    if args.kill_switch_path is not None and os.path.exists(args.kill_switch_path):
+        return True
+    else:
+        return False


### PR DESCRIPTION
Since SLURM doesn't allow one user to kill another user's SLURM job or cancel a job array, we need a way to be able to have the program abort itself quickly in situations where one user started a job and has gone away and the group needs to restart it.

So @slippylolo suggested we implement a kill-switch, which is what this PR does.

The two logical spots to insert checks are:

1. startup - to deal with job arrays
2. before each iteration of the train loop - to deal with the current run

Since multiple jobs use the same repo this kill switch can't be hardcoded, and thus each run needs to "arm" the kill switch and must use a unique path so that unintentionally other instances won't get killed.

To arm:

```
pretrain_gpt.py ... --kill-switch-path /tmp/kill-switch-tr11-200B-exp1
```

To trigger:
```
touch /tmp/kill-switch-tr11-200B-exp1
```

To deactivate and let new instances of a job run normally:

```
rm  /tmp/kill-switch-tr11-200B-exp1
```

Now where would be a good place to document this in the framework? (I will document this as well on the bigscience repo)