### PR TITLE
implement --abort-on-unmet-fused-kernel-constraints

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -563,6 +563,8 @@ def _add_training_args(parser):
                        'will be performed' )
     group.add_argument('--skip-train-iteration-range', type=str, nargs='+', default=None,
                        help='Iteration ranges to skip. The values are one or more dash-separated ranges. e.g., 101-200 251-300.')
+    group.add_argument('--abort-on-unmet-fused-kernel-constraints', action='store_true',
+                       help="If set to True, the program will abort if the constraints for loading a fused kernel aren't met")
 
     return parser
 

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -201,9 +201,11 @@ def _compile_dependencies():
             custom_kernel_constraint and
             args.masked_softmax_fusion):
         if args.rank == 0:
-            print('WARNING: constraints for invoking optimized'
-                  ' fused softmax kernel are not met. We default'
-                  ' back to unfused kernel invocations.', flush=True)
+            error = "constraints for invoking optimized fused softmax kernel are not met"
+            if args.abort_on_unmet_fused_kernel_constraints:
+                sys.exit(f"\n\nERROR: {error} and --abort-on-unmet-fused-kernel-constraints was passed. Aborting.\n\n")
+            else:
+                print(f'WARNING: {error}. We default back to unfused kernel invocations.', flush=True)
 
     # Always build on rank zero first.
     if torch.distributed.get_rank() == 0:


### PR DESCRIPTION
In those situations where we can't afford a training slowdown make sure that the program doesn't start until all the fused kernel constraints have been met.

this is of course an optional feature for when it's important.

To activate, add:

`--abort-on-unmet-fused-kernel-constraints`