### PR TITLE
[low CPU RAM] allocate on gpu directly, stagger checkpoint load/save

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -565,6 +565,9 @@ def _add_training_args(parser):
                        help='Iteration ranges to skip. The values are one or more dash-separated ranges. e.g., 101-200 251-300.')
     group.add_argument('--abort-on-unmet-fused-kernel-constraints', action='store_true',
                        help="If set to True, the program will abort if the constraints for loading a fused kernel aren't met")
+    group.add_argument('--stagger_checkpoint_save_load_group_size', type=int, default=None,
+                       help="How many processes can load/save checkpoints at once, None means not to stagger and load all at once")
+
 
     return parser
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -605,15 +605,15 @@ class ParallelTransformerLayer(MegatronModule):
                 return get_slopes_power_of_2(closest_power_of_2) + get_slopes(2 * closest_power_of_2)[0::2][
                                                                    :n - closest_power_of_2]
 
-        slopes = torch.Tensor(get_slopes(num_attention_heads))
+        slopes = torch.tensor(get_slopes(num_attention_heads))
         alibi = slopes.unsqueeze(1).unsqueeze(1) * torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(
             num_attention_heads, -1, -1)
-        
+
         #Select the part of the tensor that corresponds to our tensor parallel index.
         tp_world_size = mpu.get_tensor_model_parallel_world_size()
         tp_index = mpu.get_tensor_model_parallel_rank()
         alibi = alibi.reshape((tp_world_size, -1, *alibi.shape[1:]))[tp_index]
-        
+
         alibi = alibi.repeat(batch_size, 1, 1)
         return alibi
 
@@ -629,7 +629,7 @@ class ParallelTransformerLayerPipe(ParallelTransformerLayer):
        to the next stage in the pipeline.
 
        This version is useful if masks are dynamic.
-    
+
     2) forward(input, **kwargs) -> output
        When the mask is static over all samples, it is advantageous to
        cache the mask and avoid communicating it.

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -483,6 +483,8 @@ def tp_staggered_action():
         # staggered load_checkpoint over TP ranks
 
         tp_size = args.tensor_model_parallel_size
+
+        # XXXX: move this check to arguments.py
         assert tp_size % stagger_size == 0, f"tp_size ({tp_size}) needs to be divisible by stagger_checkpoint_save_load_group_size ({stagger_size})."
 
         # split the TP ranks into groups, each group size of stagger_size

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -462,12 +462,13 @@ from contextlib import contextmanager
 def tp_staggered_action():
     """
 
-    This context manager staggers the operation in manages across multiple ranks
+    This context manager staggers the operation it manages across multiple ranks
 
     So for example, if there is not enough CPU RAM to load all checkpoints on the node at once, we
-    can stagger those one by one or in groups to make things more efficient.
+    can stagger those one by one or in groups to make the processes consume less CPU memory
+    concurrently and thus not trigger cgroups's kill action.
 
-    The size of the group that is defined by args.stagger_checkpoint_save_load
+    The size of the group is defined by args.stagger_checkpoint_save_load
 
     """
 
@@ -485,7 +486,7 @@ def tp_staggered_action():
         assert tp_size % stagger_size == 0, f"tp_size ({tp_size}) needs to be divisible by stagger_checkpoint_save_load_group_size ({stagger_size})."
 
         # split the TP ranks into groups, each group size of stagger_size
-        # the load each group together and have the other groups wait
+        # then load each group together and have the other groups wait
         tp_rank = mpu.get_tensor_model_parallel_rank()
         ranks = list(range(tp_size))
         groups = [ranks[i:i + stagger_size] for i in range(0, tp_size, stagger_size)]

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -41,13 +41,12 @@ def model_provider(pre_process=True, post_process=True):
 
     args = get_args()
 
-    # while this is a no-op it still does something that is needed by eval tests which hang without it on tp>1
+    # while this is mostly a no-op for ZeRO<3 it inits torch.distributed and does other things
     with deepspeed.zero.Init(data_parallel_group=mpu.get_data_parallel_group(),
                              remote_device=None if args.remote_device == 'none' else args.remote_device,
                              config_dict_or_path=args.deepspeed_config,
                              enabled=args.zero_stage == 3,
                              mpu=mpu):
-
         # XXX: make `enabled` configurable or always load on GPU?
         with AllocateOnGPU(dtype=args.params_dtype, enabled=True):
             if args.deepspeed:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,2 +1,0 @@
-def test_import():
-    import megatron

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,17 +16,17 @@ def get_default_args():
     return {
         # GPT_ARGS
         "--num-layers": "2",
-        "--hidden-size": "128",
-        "--num-attention-heads": "4",
-        "--seq-length": "256",
+        "--hidden-size": "64",
+        "--num-attention-heads": "2",
+        "--seq-length": "128",
         "--max-position-embeddings": "256",
-        "--micro-batch-size": "4",
+        "--micro-batch-size": "2",
         "--global-batch-size": "8",
         "--lr-decay-iters": "320000",
         "--lr-decay-style": "cosine",
         "--lr": "0.00015",
         "--min-lr": "1.0e-5",
-        "--train-iters": "5000",
+        "--train-iters": "20",
         "--tokenizer-type": "PretrainedFromHF",
         "--tokenizer-name-or-path": "gpt2",
         "--data-impl": "mmap",
@@ -42,8 +42,8 @@ def get_default_args():
 
         # OUTPUT_ARGS
         "--log-interval": "10",
-        "--save-interval": "500",
-        "--eval-interval": "100",
+        "--save-interval": "10",
+        "--eval-interval": "10",
         "--eval-iters": "10",
         "--checkpoint-activations": "",
 
@@ -184,7 +184,7 @@ class MyTestCase(TestCasePlus):
                         equal_vectors(output[0, changed_target_index:], output_changed_target[0, changed_target_index:])
                     )
                 )
-                # Unchanged changed rows should not change either
+                # Unchanged rows should not change either
                 self.assertTrue(
                     torch.all(
                         equal_vectors(output[1, :], output_changed_target[1, :])

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -169,6 +169,17 @@ class MegDSTestTraining(TestCasePlus):
             """.split()
 
 
+        if variation == "stagger_checkpoints":
+
+            # XXX: don't enable yet as it deadlocks on save_checkpoint
+            #  --stagger_checkpoint_save_load_group_size 1
+            new_args = f"""
+            """.split()
+
+            new_ds_args = f"""
+                --deepspeed_config {self.test_file_dir_str}/ds_config.json
+            """.split()
+
         elif variation == "bnb":
             # BitsAndBytes - 8-bit optimizer
 
@@ -283,7 +294,7 @@ class MegDSTestTraining(TestCasePlus):
 
 
 
-    @parameterized.expand(["base", "cl", "bnb", "glu", "alibi"])
+    @parameterized.expand(["base", "stagger_checkpoints" "cl", "bnb", "glu", "alibi"])
     def test_training_all(self, variation):
 
         # optional runs

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -174,6 +174,7 @@ class MegDSTestTraining(TestCasePlus):
             # XXX: don't enable yet as it deadlocks on save_checkpoint
             #  --stagger_checkpoint_save_load_group_size 1
             new_args = f"""
+                --rampup-batch-size 2 2 {n_samples}
                 --train-samples {n_samples}
 
                 --lr-decay-samples 6

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -169,11 +169,14 @@ class MegDSTestTraining(TestCasePlus):
             """.split()
 
 
-        if variation == "stagger_checkpoints":
+        elif variation == "stagger_checkpoints":
 
             # XXX: don't enable yet as it deadlocks on save_checkpoint
             #  --stagger_checkpoint_save_load_group_size 1
             new_args = f"""
+                --train-samples {n_samples}
+
+                --lr-decay-samples 6
             """.split()
 
             new_ds_args = f"""

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -294,7 +294,7 @@ class MegDSTestTraining(TestCasePlus):
 
 
 
-    @parameterized.expand(["base", "stagger_checkpoints" "cl", "bnb", "glu", "alibi"])
+    @parameterized.expand(["base", "stagger_checkpoints", "cl", "bnb", "glu", "alibi"])
     def test_training_all(self, variation):
 
         # optional runs


### PR DESCRIPTION
As we are dealing with CPU RAM < GPU RAM this PR is trying 

1. to init the model on GPU by allocating the model on gpu directly
Code is courtesy of @jeffra with a demo at https://gist.github.com/jeffra/ec8a0b762e58a64d19ad1417250dc600

The idea was to remove `deepspeed.zero.Init` as supposedly it wasn't really doing anything under zero1, but when I did that the tp test started hanging. So I put it back and double inserted `AllocateOnGPU` in a nested fashion. `deepspeed.zero.Init` actually does a whole bunch of things regardless of ZeRO stage.

2. stagger save/load_checkpoints in groups defined by `--stagger_checkpoint_save_load_group_size` - if not set normal all processes at once is performed. 

This works on `load_checkpoint`, but hangs on `save_checkpoint` - I think it deadlocks since  `save_checkpoint` probably calls a `barrier` too.

-------------

3. while at it sped up several tests by making the test model smaller and training for 50x shorter.
