### PR TITLE
Try to read the data path arguments directly from a file

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -860,8 +860,9 @@ def _add_data_args(parser):
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
                 assert lines[0][-1:] == "\"" and lines[0][0] == "\"", f"WTF {lines}"
                 values = lines[0][1:-1].split("\" \"")
-                setattr(args, re.sub(r"-path$", "", self.dest.replace), values)
-                parse_data_paths(parser, args, values)
+                weighted_split_paths_option = re.sub(r"-path$", "", self.dest.replace)
+                setattr(args, weighted_split_paths_option, values)
+                parse_data_paths(parser, args, values, option_string=weighted_split_paths_option)
 
 
     group.add_argument('--train-weighted-split-paths-path', type=str, action=parse_data_paths_path ,default=None)

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -850,7 +850,7 @@ def _add_data_args(parser):
                 lines = fi.readlines()
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
                 assert lines[0][-2:] == "\"\n" and lines[0][0] == "\"", f"Invalid input format, got {lines}"
-                values = lines[0][1:-1].split("\" \"")
+                values = lines[0][1:-2].split("\" \"")
                 weighted_split_paths_dest = re.sub(r"_path$", "", self.dest)
                 weighted_split_paths_option = re.sub(r"-path$", "", self.option_strings[0])
                 setattr(args, weighted_split_paths_dest, values)

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -843,15 +843,8 @@ def _add_data_args(parser):
 
     class parse_data_paths_path(argparse.Action):
         def __call__(self, parser, args, values, option_string=None):
-            assert len(values) == 1
-
-            # make sure string given in the correct format
-            err_message = 'Each data group should be input on the following format'
-            '"GIVEN_NAME WEIGHT1 START:END PATH1, WEIGHT2 START:END PATH2"'
-            'where START < END'
-
             if option_string in ["--train-weighted-split-paths-path", "--valid-weighted-split-paths-path", "--test-weighted-split-paths-path"]:
-                filename = values[0]
+                filename = values
             else:
                 raise NotImplementedError()
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -851,7 +851,7 @@ def _add_data_args(parser):
             with open(filename, "r") as fi:
                 lines = fi.readlines()
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
-                assert lines[0][-1:] == "\"\n" and lines[0][0] == "\"", f"Invalid input format, got {lines}"
+                assert lines[0][-2:] == "\"\n" and lines[0][0] == "\"", f"Invalid input format, got {lines}"
                 values = lines[0][1:-1].split("\" \"")
                 weighted_split_paths_dest = re.sub(r"_path$", "", self.dest)
                 weighted_split_paths_option = re.sub(r"-path$", "", self.option_strings[0])

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -851,7 +851,7 @@ def _add_data_args(parser):
             with open(filename, "r") as fi:
                 lines = fi.readlines()
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
-                assert lines[0][-1:] == "\"" and lines[0][0] == "\"", f"WTF {lines}"
+                assert lines[0][-1:] == "\"\n" and lines[0][0] == "\"", f"Invalid input format, got {lines}"
                 values = lines[0][1:-1].split("\" \"")
                 weighted_split_paths_dest = re.sub(r"_path$", "", self.dest)
                 weighted_split_paths_option = re.sub(r"-path$", "", self.option_strings[0])

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -862,7 +862,7 @@ def _add_data_args(parser):
                 values = lines[0][1:-1].split("\" \"")
                 weighted_split_paths_option = re.sub(r"-path$", "", self.dest.replace)
                 setattr(args, weighted_split_paths_option, values)
-                parse_data_paths(parser, args, values, option_string=weighted_split_paths_option)
+                parse_data_paths()(parser, args, values, option_string=weighted_split_paths_option)
 
 
     group.add_argument('--train-weighted-split-paths-path', type=str, action=parse_data_paths_path ,default=None)

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -860,9 +860,10 @@ def _add_data_args(parser):
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
                 assert lines[0][-1:] == "\"" and lines[0][0] == "\"", f"WTF {lines}"
                 values = lines[0][1:-1].split("\" \"")
-                weighted_split_paths_option = re.sub(r"-path$", "", self.dest.replace)
-                setattr(args, weighted_split_paths_option, values)
-                parse_data_paths()(parser, args, values, option_string=weighted_split_paths_option)
+                weighted_split_paths_dest = re.sub(r"_path$", "", self.dest)
+                weighted_split_paths_option = re.sub(r"-path$", "", self.option_strings[0])
+                setattr(args, weighted_split_paths_dest, values)
+                parse_data_paths(option_strings=[weighted_split_paths_option], dest=weighted_split_paths_dest)(parser, args, values, option_string=weighted_split_paths_option)
 
 
     group.add_argument('--train-weighted-split-paths-path', type=str, action=parse_data_paths_path ,default=None)

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -95,6 +95,27 @@ def parse_args(extra_args_provider=None, defaults={},
                   args.tensor_model_parallel_size,
                   args.pipeline_model_parallel_size), flush=True)
 
+    if args.train_weighted_split_paths_path:
+        with open(args.train_weighted_split_paths_path, "r") as fi:
+            lines = fi.readlines()
+            assert len(lines) == 1
+            assert lines[0][-1] == "\n"
+            args.train_weighted_split_paths = lines[0][:-1]
+
+    if args.valid_weighted_split_paths_path:
+        with open(args.valid_weighted_split_paths_path, "r") as fi:
+            lines = fi.readlines()
+            assert len(lines) == 1
+            assert lines[0][-1] == "\n"
+            args.valid_weighted_split_paths = lines[0][:-1]
+
+    if args.test_weighted_split_paths_path:
+        with open(args.test_weighted_split_paths_path, "r") as fi:
+            lines = fi.readlines()
+            assert len(lines) == 1
+            assert lines[0][-1] == "\n"
+            args.test_weighted_split_paths = lines[0][:-1]
+
     # --data-path and --train-weighted-splits-paths
     message = "Data loading Mode 1: --data-path and --split "\
             "and Mode 2: --(train|valid|test)-weighted-split-paths"\

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -843,12 +843,10 @@ def _add_data_args(parser):
 
     class parse_data_paths_path(argparse.Action):
         def __call__(self, parser, args, values, option_string=None):
-            if option_string in ["--train-weighted-split-paths-path", "--valid-weighted-split-paths-path", "--test-weighted-split-paths-path"]:
-                filename = values
-            else:
-                raise NotImplementedError()
+            expected_option_strings = ["--train-weighted-split-paths-path", "--valid-weighted-split-paths-path", "--test-weighted-split-paths-path"]
+            assert option_string in expected_option_strings, f"Expected {option_string} to be in {expected_option_strings}"
 
-            with open(filename, "r") as fi:
+            with open(values, "r") as fi:
                 lines = fi.readlines()
                 assert len(lines) == 1, f"Got multiple lines {len(lines)} instead of 1 expected"
                 assert lines[0][-2:] == "\"\n" and lines[0][0] == "\"", f"Invalid input format, got {lines}"


### PR DESCRIPTION
this PR adds support for:
```
--train-weighted-split-paths-path /gpfswork/rech/six/commun/code/tr8b-104B/Megatron-DeepSpeed/data/train-splits.txt     
--valid-weighted-split-paths-path /gpfswork/rech/six/commun/code/tr8b-104B/Megatron-DeepSpeed/data/valid-splits.txt     
--test-weighted-split-paths-path /gpfswork/rech/six/commun/code/tr8b-104B/Megatron-DeepSpeed/data/test-splits.txt  
```
since cmd line is limited to 128k and the contents of the above files are longer that that - so it fails to start.
