### PR TITLE
make partition_method configurable

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -565,6 +565,8 @@ def _add_training_args(parser):
                        help='Iteration ranges to skip. The values are one or more dash-separated ranges. e.g., 101-200 251-300.')
     group.add_argument('--abort-on-unmet-fused-kernel-constraints', action='store_true',
                        help="If set to True, the program will abort if the constraints for loading a fused kernel aren't met")
+    group.add_argument('--pp-partition-method', type=str, default=None,
+                       help='Use to override the pipeline stages partition method. e.g., "type:transformer|embed"')
 
     return parser
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -566,7 +566,7 @@ def _add_training_args(parser):
     group.add_argument('--abort-on-unmet-fused-kernel-constraints', action='store_true',
                        help="If set to True, the program will abort if the constraints for loading a fused kernel aren't met")
     group.add_argument('--pp-partition-method', type=str, default=None,
-                       help='Use to override the pipeline stages partition method. e.g., "type:transformer|embed"')
+                       help="Use to override the pipeline stages partitioning method. e.g., 'type:transformer|embedding'")
 
     return parser
 

--- a/megatron/model/gpt_model.py
+++ b/megatron/model/gpt_model.py
@@ -302,7 +302,7 @@ class GPTModelPipe(PipelineModule,MegatronModule):
                                              num_dp=mpu.get_data_parallel_world_size())
 
         # here one can extend the regex to include more layers to be counted towards partitioning,
-        # e.g. "type:transformer|embed" will add up all the transformer blocks and also the first
+        # e.g. 'type:transformer|embedding' will add up all the transformer blocks and also the first
         # and last embedding layers and then partition that transformers+2 layers - so to get a good
         # balance you may want to use less transformer layers
         #


### PR DESCRIPTION
This PR allows one to set `--pp-partition-method 'type:transformer|embed'` to consider embedding layers on par with transformer layers when partitioning over PP stages. For large 250k vocab which takes about the same amount of memory as the transformer block this allows to balance memory usage between all stages - w/o it pp rank 0 and -1 use much more gpu memory than other stages. 