### PR TITLE
[embed norm] switch to apex MixedFusedLayerNorm

### DIFF
--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -36,6 +36,7 @@ from .random import get_cuda_rng_tracker
 from .utils import divide
 from .utils import split_tensor_along_last_dim
 from .utils import VocabUtility
+from ..model.fused_layer_norm import MixedFusedLayerNorm as LayerNorm
 from megatron import get_args, mpu
 import deepspeed.runtime.activation_checkpointing.checkpointing as ds_checkpointing
 
@@ -191,7 +192,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         # only the first stage embedding runs this class' forward. The head's embedding does its own
         # thing, so don't waste memory allocating LN weights.
         if mpu.is_pipeline_first_stage() and (args.use_bnb_optimizer or args.embed_layernorm):
-            self.norm = torch.nn.LayerNorm(embedding_dim)
+            self.norm = LayerNorm(embedding_dim)
 
         if args.use_bnb_optimizer:
             # for BNB we ignore the passed init_method and use torch.nn.init.xavier_uniform_


### PR DESCRIPTION
as noticed by @thomasw21 - switching embed layernorm to use `MixedFusedLayerNorm` for consistency with other layer norms.

-----------------

Incidentally, this also fixes a bug with how `torch.nn.LayerNorm`  was used until now.

the framework was putting `LayerNorm` into the wrong param group here:
https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/dd06ea32e014d8db6cdaf5e6839071d6523ca83c/megatron/optimizer/__init__.py#L31-L45

it should have been in `no_weight_decay_params` but ended up in `weight_decay_params` because in this module `LayerNorm` is an alias for `MixedFusedLayerNorm`, so if `isinstance(module_, LayerNorm)` was `False`.

So if we want to use `torch.nn.LayerNorm` we have to change the code above to additionally check for ` or isinstance(module_, torch.nn.LayerNorm).`
