### PR TITLE
[TB] disable samples-per-dataset, steps-per-dataset, tokens-per-dataset

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -658,12 +658,15 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             writer.add_scalar('curriculum_seqlen', args.curriculum_seqlen,
                               iteration)
 
-        if args.data_weights is not None:
-            for prefix, weight in zip(args.data_prefixes, args.data_weights):
-                name = prefix.split(",")[-1]
-                writer.add_scalar(f'samples-per-dataset/{name}', args.consumed_train_samples * weight, args.consumed_train_samples)
-                writer.add_scalar(f'steps-per-dataset/{name}', iteration * weight, iteration)
-                writer.add_scalar(f'tokens-per-dataset/{name}', args.consumed_train_tokens * weight, args.consumed_train_tokens)
+        # It's very questionable what this data contributes, other than huge unstripped file paths
+        # as keys and hundreds of TB boards that make the TB files very bloated. So disabling for now.
+        #
+        # if args.data_weights is not None:
+        #     for prefix, weight in zip(args.data_prefixes, args.data_weights):
+        #         name = prefix.split(",")[-1]
+        #         writer.add_scalar(f'samples-per-dataset/{name}', args.consumed_train_samples * weight, args.consumed_train_samples)
+        #         writer.add_scalar(f'steps-per-dataset/{name}', iteration * weight, iteration)
+        #         writer.add_scalar(f'tokens-per-dataset/{name}', args.consumed_train_tokens * weight, args.consumed_train_tokens)
 
         if args.log_timers_to_tensorboard:
             timers.write(timers_to_log, writer, iteration,


### PR DESCRIPTION
It's very questionable what this data contributes, other than huge unstripped file paths as keys and hundreds of TB boards that make the TB files very bloated. So disabling for now.

Here is a sample of the current single key: 

`tokens-per-dataset//gpfsscratch/rech/six/commun/bigscience-datasets/merged-meg-ds_v3_pii/ar/bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles_ar_text_document
tag: tokens-per-dataset//gpfsscratch/rech/six/commun/bigscience-datasets/merged-meg-ds_v3_pii/ar/bigscience-catalogue-data-dev_byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles_ar_text_document`

Still need to go back and strip this data out of the already existing TB files.
