### PR TITLE
Make dataloader use another random generator

### DIFF
--- a/megatron/data/data_samplers.py
+++ b/megatron/data/data_samplers.py
@@ -52,6 +52,7 @@ def build_pretraining_data_loader(dataset, consumed_samples):
     return torch.utils.data.DataLoader(dataset,
                                        batch_sampler=batch_sampler,
                                        num_workers=args.num_workers,
+                                       generator=torch.Generator().manual_seed(args.seed),
                                        pin_memory=True)
 
 class MegatronPretrainingSampler:


### PR DESCRIPTION
This is in order to start synchronizing the dropout across TP.