### PR TITLE
Fix mixed fused layer norm to mimick nn.LayerNorm for torch>1.11

### DIFF
--- a/megatron/fused_kernels/layer_norm_cuda_kernel.cu
+++ b/megatron/fused_kernels/layer_norm_cuda_kernel.cu
@@ -317,7 +317,7 @@ void cuApplyLayerNorm(
     if (gamma != NULL && beta != NULL) {
       for (int i = thrx;  i < n2;  i+=numx) {
         U curr = static_cast<U>(lvals[i]);
-        ovals[i] = gamma[i] * static_cast<V>(c_invvar * (curr - mu)) + beta[i];
+        ovals[i] = (curr - mu) * c_invvar * static_cast<U>(gamma[i]) + static_cast<U>(beta[i]);
       }
     } else {
       for (int i = thrx;  i < n2;  i+=numx) {

--- a/megatron/fused_kernels/layer_norm_cuda_kernel.cu
+++ b/megatron/fused_kernels/layer_norm_cuda_kernel.cu
@@ -287,7 +287,7 @@ struct SharedMemory <float>
 
 }
 
-template<typename T, typename U, typename V, typename W> __global__
+template<typename T, typename U, typename V> __global__
 void cuApplyLayerNorm(
   V* __restrict__ output_vals,
   U* __restrict__ mean,
@@ -296,8 +296,8 @@ void cuApplyLayerNorm(
   const int n1,
   const int n2,
   const U epsilon,
-  const W* __restrict__ gamma,
-  const W* __restrict__ beta
+  const V* __restrict__ gamma,
+  const V* __restrict__ beta
   ) 
 {
   // Assumptions:
@@ -653,7 +653,7 @@ void cuComputeGradInput(
 
 
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V> 
 void HostApplyLayerNorm(
     V* output,
     U* mean,
@@ -662,8 +662,8 @@ void HostApplyLayerNorm(
     int n1,
     int n2,
     double epsilon,
-    const W* gamma,
-    const W* beta
+    const V* gamma,
+    const V* beta
     )
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -703,8 +703,6 @@ void cuda_layer_norm(
     double epsilon)
 {
     using namespace at;
-    gamma_float = gamma != NULL ? (*gamma).to(at::ScalarType::Float) : NULL;
-    beta_float = beta != NULL ? (*beta).to(at::ScalarType::Float) : NULL;
     DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
         input->scalar_type(), output->scalar_type(), "cuda_layer_norm_kernel",
         HostApplyLayerNorm(
@@ -714,8 +712,8 @@ void cuda_layer_norm(
 	    input->DATA_PTR<scalar_t_in>(),
 	    n1,n2,
 	    epsilon,
-	    gamma_float != NULL ? gamma_float.data_ptr() : NULL,
-	    beta_float != NULL ? beta_float.data_ptr() : NULL);
+	    gamma != NULL ? gamma->DATA_PTR<scalar_t_out>() : NULL,
+	    beta != NULL ? beta->DATA_PTR<scalar_t_out>() : NULL);
       )
 }
 

--- a/megatron/fused_kernels/layer_norm_cuda_kernel.cu
+++ b/megatron/fused_kernels/layer_norm_cuda_kernel.cu
@@ -287,7 +287,7 @@ struct SharedMemory <float>
 
 }
 
-template<typename T, typename U, typename V> __global__
+template<typename T, typename U, typename V, typename W> __global__
 void cuApplyLayerNorm(
   V* __restrict__ output_vals,
   U* __restrict__ mean,
@@ -296,8 +296,8 @@ void cuApplyLayerNorm(
   const int n1,
   const int n2,
   const U epsilon,
-  const V* __restrict__ gamma,
-  const V* __restrict__ beta
+  const W* __restrict__ gamma,
+  const W* __restrict__ beta
   ) 
 {
   // Assumptions:
@@ -653,7 +653,7 @@ void cuComputeGradInput(
 
 
 
-template<typename T, typename U, typename V> 
+template<typename T, typename U, typename V, typename W>
 void HostApplyLayerNorm(
     V* output,
     U* mean,
@@ -662,8 +662,8 @@ void HostApplyLayerNorm(
     int n1,
     int n2,
     double epsilon,
-    const V* gamma,
-    const V* beta
+    const W* gamma,
+    const W* beta
     )
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -703,6 +703,8 @@ void cuda_layer_norm(
     double epsilon)
 {
     using namespace at;
+    gamma_float = gamma != NULL ? (*gamma).to(at::ScalarType::Float) : NULL;
+    beta_float = beta != NULL ? (*beta).to(at::ScalarType::Float) : NULL;
     DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
         input->scalar_type(), output->scalar_type(), "cuda_layer_norm_kernel",
         HostApplyLayerNorm(
@@ -712,8 +714,8 @@ void cuda_layer_norm(
 	    input->DATA_PTR<scalar_t_in>(),
 	    n1,n2,
 	    epsilon,
-	    gamma != NULL ? gamma->DATA_PTR<scalar_t_out>() : NULL,
-	    beta != NULL ? beta->DATA_PTR<scalar_t_out>() : NULL);
+	    gamma_float != NULL ? gamma_float.data_ptr() : NULL,
+	    beta_float != NULL ? beta_float.data_ptr() : NULL);
       )
 }
 

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -18,6 +18,8 @@
    with some changes. """
 
 import numbers
+
+from packaging import version
 import torch
 from torch import nn
 from torch.nn.parameter import Parameter
@@ -82,12 +84,10 @@ class MixedFusedLayerNorm(torch.nn.Module):
 
     args = get_args()
 
-    TORCH_MAJOR, TORCH_MINOR = tuple(int(elt) for elt in torch.__version__.split(".")[:2])
-    # Check that pytorch version is higher that 1.11
-    if args.bf16 or (TORCH_MAJOR == 1 and TORCH_MINOR < 11) or TORCH_MAJOR < 1:
-        self.use_meg_ds_fused_layer_norm = True
-    else:
-        self.use_meg_ds_fused_layer_norm = False
+    self.use_meg_ds_fused_layer_norm = (
+      args.bf16 # Current Meg-DS cuda kernel has better throughput than torch.nn.LayerNorm
+      or version.parse(torch.__version__) > version.parse("1.11.0") # https://github.com/pytorch/pytorch/pull/66920
+    )
 
 
   def reset_parameters(self):

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -84,10 +84,10 @@ class MixedFusedLayerNorm(torch.nn.Module):
 
     TORCH_MAJOR, TORCH_MINOR = tuple(int(elt) for elt in torch.__version__.split(".")[:2])
     # Check that pytorch version is higher that 1.11
-    if ((TORCH_MAJOR == 1 and TORCH_MINOR >= 11) or TORCH_MAJOR > 1) and args.bf16 is False:
-        self.use_meg_ds_fused_layer_norm = False
-    else:
+    if args.bf16 or (TORCH_MAJOR == 1 and TORCH_MINOR < 11) or TORCH_MAJOR < 1:
         self.use_meg_ds_fused_layer_norm = True
+    else:
+        self.use_meg_ds_fused_layer_norm = False
 
 
   def reset_parameters(self):

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -89,7 +89,7 @@ class _MixedFusedLayerNorm(torch.nn.Module):
     return FusedLayerNormAffineFunction.apply(
       input, self.weight, self.bias, self.normalized_shape,self.eps)
 
-TORCH_MAJOR, TORCH_MINOR = tuple(int(elt) for elt in torch.__version__.split("."))
+TORCH_MAJOR, TORCH_MINOR = tuple(int(elt) for elt in torch.__version__.split(".")[:2])
 # Check that pytorch version is higher that 1.11
 if (TORCH_MAJOR == 1 and TORCH_MINOR >= 11) or TORCH_MAJOR > 2:
     MixedFusedLayerNorm = nn.LayerNorm

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -84,7 +84,7 @@ class MixedFusedLayerNorm(torch.nn.Module):
 
     TORCH_MAJOR, TORCH_MINOR = tuple(int(elt) for elt in torch.__version__.split(".")[:2])
     # Check that pytorch version is higher that 1.11
-    if (TORCH_MAJOR == 1 and TORCH_MINOR >= 11) or TORCH_MAJOR > 2 and args.bf16 is False:
+    if ((TORCH_MAJOR == 1 and TORCH_MINOR >= 11) or TORCH_MAJOR > 1) and args.bf16 is False:
         self.use_meg_ds_fused_layer_norm = False
     else:
         self.use_meg_ds_fused_layer_norm = True

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -86,7 +86,7 @@ class MixedFusedLayerNorm(torch.nn.Module):
 
     self.use_meg_ds_fused_layer_norm = (
       args.bf16 # Current Meg-DS cuda kernel has better throughput than torch.nn.LayerNorm
-      or version.parse(torch.__version__) > version.parse("1.11.0") # https://github.com/pytorch/pytorch/pull/66920
+      or version.parse(torch.__version__) >= version.parse("1.11.0") # https://github.com/pytorch/pytorch/pull/66920
     )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -303,7 +303,7 @@ class MyTestCase(TestCasePlus):
                     torch_layer_norm_output = F.layer_norm(dummy_input, normalized_shape, weight, bias, eps=epsilon)
                 else:
                     # In this case we use can check that basically it corresponds to the fp32 version
-                    torch_layer_norm_output = F.layer_norm(dummy_input, normalized_shape, weight.float(), bias.float(), eps=epsilon).to(torch.bfloat16)
+                    torch_layer_norm_output = F.layer_norm(dummy_input.float(), normalized_shape, weight.float(), bias.float(), eps=epsilon).to(torch.bfloat16)
 
                 torch_assert_equal(mfln_output, torch_layer_norm_output)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -282,7 +282,7 @@ class MyTestCase(TestCasePlus):
                 initialize_megatron()
                 args = get_args()
 
-                dummy_input = torch.randn(args.micro_batch_size, args.seq_length, args.hidden_size, device="cuda")
+                dummy_input = torch.randn(args.micro_batch_size, args.seq_length, args.hidden_size, device="cuda", dtype=torch.bfloat16)
 
                 normalized_shape = (args.hidden_size,)
                 epsilon = 1e-5
@@ -292,8 +292,8 @@ class MyTestCase(TestCasePlus):
                 self.assertTrue(args.bf16, "Test has to be done in half precision.")
 
                 # We set the weight manually so we simulate state that's not the initialisation
-                weight = torch.randn(args.hidden_size, device="cuda")
-                bias = torch.randn(args.hidden_size, device="cuda")
+                weight = torch.randn(args.hidden_size, device="cuda", dtype=torch.bfloat16)
+                bias = torch.randn(args.hidden_size, device="cuda", dtype=torch.bfloat16)
                 mfln.weight = nn.Parameter(weight)
                 mfln.bias = nn.Parameter(bias)
 


### PR DESCRIPTION
Above pytorch>=1.11 this makes sense as the cuda kernels allow fp32 accumulation. Also we've "fixed" the `MixedFusedLayerNorm` to do the rescaling operation in float32 before casting.