### PR TITLE
[valid] deadlock workaround

### DIFF
--- a/megatron/data/data_samplers.py
+++ b/megatron/data/data_samplers.py
@@ -22,7 +22,7 @@ from megatron import get_args
 from megatron import mpu
 
 
-def build_pretraining_data_loader(dataset, consumed_samples):
+def build_pretraining_data_loader(dataset, consumed_samples, num_workers=None):
     """Buld dataloader given an input dataset."""
 
     if dataset is None:
@@ -48,10 +48,13 @@ def build_pretraining_data_loader(dataset, consumed_samples):
         raise Exception('{} dataloader type is not supported.'.format(
                 args.dataloader_type))
 
+    if num_workers is None:
+        num_workers = args.num_workers
+
     # Torch dataloader.
     return torch.utils.data.DataLoader(dataset,
                                        batch_sampler=batch_sampler,
-                                       num_workers=args.num_workers,
+                                       num_workers=num_workers,
                                        pin_memory=True)
 
 class MegatronPretrainingSampler:
@@ -141,7 +144,7 @@ class MegatronPretrainingRandomSampler:
                        * self.micro_batch_size
         bucket_offset = current_epoch_samples // self.data_parallel_size
         start_idx = self.data_parallel_rank * bucket_size
-        
+
         g = torch.Generator()
         g.manual_seed(self.epoch)
         random_idx = torch.randperm(bucket_size, generator=g).tolist()

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1132,7 +1132,9 @@ def build_train_valid_test_data_iterators(
 
         # We collapse None and empty list as both should mean we don't run validation
         # args.consumed_valid_samples accumulates the sum of valid steps for every dataset, which are all equal
-        valid_dataloaders = [build_pretraining_data_loader(d, args.consumed_valid_samples // len(valid_ds))
+        # XXX: we get a deadlock in the dataloader on eval, possibly this bug in pytorch https://github.com/pytorch/pytorch/pull/25158
+        # using num_workers=0 to work around it - the training can't use that since it impacts throughput by a few percent
+        valid_dataloaders = [build_pretraining_data_loader(d, args.consumed_valid_samples // len(valid_ds), num_workers=0)
                             for d in valid_ds] \
                             if valid_ds is not None else []
         # We collapse None and empty list as both should mean we don't run test


### PR DESCRIPTION
https://huggingface.slack.com/archives/C01NHER1JLS/p1652884593515729

1. We again run into a deadlock on the 2nd valid loss entry
2. This time the srun py-spy tracer worked perfectly so we had all the info needed to analyse the problem
3. @Daniel Hesslow discovered that the deadlock happens in DataLoader - i.e. pytorch bug https://github.com/pytorch/pytorch/pull/25158 - which was supposed to be fixed, but it's not - the race condition is still there - and other recent comments confirm that.
4. So based on Daniel's suggestion we set the valid_dataloaders to use num_workers=0 to work around it - it slows things down by a 5 TFLOPs on training, so we kept the training at num_workers=2

@TevenLeScao, @thomasw21 
