### PR TITLE
Fix tflops glu computation

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -692,6 +692,9 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         # The factor of 4 is when used with activation check-pointing,
         # otherwise it will be 3, but for 200B model, activation check-pointing will always be on.
         checkpoint_activations_factor = 4 if args.checkpoint_activations else 3
+        # GLU activations double the hidden states in the upscaling feed-forward in the each transformer layer
+        # This leads to 16bsh^2 instead of 8bsh^2 per feed-forward layer, thus we increase the coefficient by 8.
+        # Refer to https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/283#issue-1260805063 for more details.
         coefficient = 32 if args.glu_activation else 24
         flops_per_iteration = (coefficient * checkpoint_activations_factor * batch_size * seq_len * num_layers * (hidden_size**2)) * (1. + (seq_len / (6. * hidden_size)) + (vocab_size / (16. * num_layers * hidden_size)))
         tflops = flops_per_iteration / (elapsed_time_per_iteration * args.world_size * (10**12))

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -692,7 +692,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         # The factor of 4 is when used with activation check-pointing,
         # otherwise it will be 3, but for 200B model, activation check-pointing will always be on.
         checkpoint_activations_factor = 4 if args.checkpoint_activations else 3
-        # GLU activations double the hidden states in the upscaling feed-forward in the each transformer layer
+        # GLU activations double the hidden states in the upscaling feed-forward in each transformer layer
         # This leads to 16bsh^2 instead of 8bsh^2 per feed-forward layer, thus we increase the coefficient by 8.
         # Refer to https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/283#issue-1260805063 for more details.
         coefficient = 32 if args.glu_activation else 24

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -692,7 +692,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         # The factor of 4 is when used with activation check-pointing,
         # otherwise it will be 3, but for 200B model, activation check-pointing will always be on.
         checkpoint_activations_factor = 4 if args.checkpoint_activations else 3
-        flops_per_iteration = (24 * checkpoint_activations_factor * batch_size * seq_len * num_layers * (hidden_size**2)) * (1. + (seq_len / (6. * hidden_size)) + (vocab_size / (16. * num_layers * hidden_size)))
+        coefficient = 32 if args.glu_activation else 24
+        flops_per_iteration = (coefficient * checkpoint_activations_factor * batch_size * seq_len * num_layers * (hidden_size**2)) * (1. + (seq_len / (6. * hidden_size)) + (vocab_size / (16. * num_layers * hidden_size)))
         tflops = flops_per_iteration / (elapsed_time_per_iteration * args.world_size * (10**12))
 
         # only the last rank process has a non-None _GLOBAL_TENSORBOARD_WRITER

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -693,7 +693,7 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         # otherwise it will be 3, but for 200B model, activation check-pointing will always be on.
         checkpoint_activations_factor = 4 if args.checkpoint_activations else 3
         # GLU activations double the hidden states in the upscaling feed-forward in each transformer layer
-        # This leads to 16bsh^2 instead of 8bsh^2 per feed-forward layer, thus we increase the coefficient by 8.
+        # This leads to 16bsh^2 instead of 8bsh^2 per first feed-forward layer in MLP, thus we increase the coefficient by 8.
         # Refer to https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/283#issue-1260805063 for more details.
         coefficient = 32 if args.glu_activation else 24
         flops_per_iteration = (coefficient * checkpoint_activations_factor * batch_size * seq_len * num_layers * (hidden_size**2)) * (1. + (seq_len / (6. * hidden_size)) + (vocab_size / (16. * num_layers * hidden_size)))


### PR DESCRIPTION
From [Efficient Large-Scale Language Model Training on GPU Clusters Using Megatron-LM](https://arxiv.org/pdf/2104.04473.pdf):

> A `𝐴𝑚×𝑘 ×𝑋𝑘×𝑛` matrix multiplication requires `2𝑚 ×𝑘 ×𝑛` FLOPs
> 
> The feed-forward network increases the hidden size to 4ℎ and then reduces it back to ℎ; this requires `16𝐵𝑠ℎ^2` FLOP

We know that
```
Normal
(b, s, h) * (h, h*4)
SwiGLU
(b, s, h) * (h, h*8)
```
Hence

* Normal

`B*(2 * s * h * (h*4)) = b*(8sh^2) = 8bsh^2 -> * 2` for downscaling again -> `16bsh^2` (This turns then into `24𝐵𝑠ℎ^2 + 4𝐵𝑠2ℎ + ...`  with some additional operations, see the paper)

* SwiGLU
 
`B*(2 * s * h * (h*8)) = b*(16sh^2) = 16bsh^2 (upscaling) + SwiGLU + 8bsh^2 (downscaling) `-> `24bsh^2` (-> We need to add 8, thus `32𝐵𝑠ℎ^2 + 4𝐵𝑠2ℎ + ...`)

I.e. we need to increase the coefficient by 8.

The SwiGLU operation also adds another `0.5*bsh*8` I think, but ignoring them here for simplicity. Kudos to @DanielHesslow!