### PR TITLE
Initialize dist with DS

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -290,9 +290,7 @@ def _initialize_distributed():
                 args.local_rank = device
             torch.cuda.set_device(device)
         # Call the init process
-        torch.distributed.init_process_group(
-            backend=args.distributed_backend,
-            world_size=args.world_size, rank=args.rank)
+        deepspeed.init_distributed(args.distributed_backend)
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.


### PR DESCRIPTION
Currently, `deepspeed.comm.get_rank` is called before `deepspeed.init_distributed`, leading to a DS assertion error such as:

`AssertionError: DeepSpeed backend not set, please initialize it using init_process_group()`

If we replace `torch.distributed.init_process_group` with `deepspeed.init_distributed`, DS will both internally call `torch.distributed.init_process_group`, and the DS assertion will pass.

Successfully tested with `make test`