### PR TITLE
Add Bitfit

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -476,7 +476,8 @@ def _add_regularization_args(parser):
                        'numerical stability')
     group.add_argument('--sgd-momentum', type=float, default=0.9,
                        help='Momentum factor for sgd')
-
+    group.add_argument('--bitfit', action='store_true',
+                       help='Use BitFit')
     return parser
 
 

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -60,7 +60,10 @@ def _get_params_for_weight_decay_optimization(modules):
     #return weight_decay_params, no_weight_decay_params
 
 def _get_params_for_bitfit(modules):
-    """Get params to do BitFit"""
+    """
+    Get params to do BitFit
+    See https://arxiv.org/abs/2106.10199
+    """
     # No weight (bias) decay is used
     no_weight_decay_params = {'params': [], 'weight_decay': 0.0}
     for module in modules:
@@ -69,8 +72,7 @@ def _get_params_for_bitfit(modules):
                     [p for n, p in list(module_._parameters.items())
                      if p is not None and 'bias' in n])
 
-    # TODO: Add dummy parameters
-    return no_weight_decay_params
+    return no_weight_decay_params,
 
 def get_megatron_optimizer(model):
     args = get_args()


### PR DESCRIPTION
This PR adds compatibility for BitFit. I'd like to try BitFit + MTF to retain Multilinguality.

<img width="965" alt="Screenshot 2022-07-10 at 19 59 16" src="https://user-images.githubusercontent.com/62820084/178156543-41be2186-269a-4561-afa1-a05fdad8ac62.png">

Note that adapters also add parameters to the model & increase complexity at inference in Transformers, so BF is the best option imo.


Automatic Tests: Happy to add one if we decide to merge this 🤗

Manual Tests:
- 1 Nodes, PP=2, TP=2
- 2 Nodes, PP=2, TP=2

The below shows how the grad norm decreases as it should & training slightly speeds up. It speeds up even more the more parallelism is used due to less communication.

Without BitFit
```bash
[default3]: iteration        5/  868457 | consumed samples:          960 | consumed tokens:      1966080 | elapsed time per iteration (s): 14.84 | learning rate: 1.573E-06 | global batch size:   192 | lm loss: 1.244031E+01 | loss scale: 4096.0 | grad norm: 0.063 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.939 | TFLOPs: 23.66 |
[default3]: iteration        6/  868457 | consumed samples:         1152 | consumed tokens:      2359296 | elapsed time per iteration (s): 14.91 | learning rate: 1.887E-06 | global batch size:   192 | lm loss: 1.244197E+01 | loss scale: 4096.0 | grad norm: 0.062 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.874 | TFLOPs: 23.55 |
[default3]: iteration        7/  868457 | consumed samples:         1344 | consumed tokens:      2752512 | elapsed time per iteration (s): 14.90 | learning rate: 2.202E-06 | global batch size:   192 | lm loss: 1.244066E+01 | loss scale: 4096.0 | grad norm: 0.062 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.890 | TFLOPs: 23.57 |
[default3]: iteration        8/  868457 | consumed samples:         1536 | consumed tokens:      3145728 | elapsed time per iteration (s): 14.97 | learning rate: 2.517E-06 | global batch size:   192 | lm loss: 1.243888E+01 | loss scale: 4096.0 | grad norm: 0.064 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.829 | TFLOPs: 23.46 |
[default3]: iteration        9/  868457 | consumed samples:         1728 | consumed tokens:      3538944 | elapsed time per iteration (s): 14.96 | learning rate: 2.831E-06 | global batch size:   192 | lm loss: 1.243974E+01 | loss scale: 4096.0 | grad norm: 0.063 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.836 | TFLOPs: 23.47 |
```

No BitFit
```bash
[default3]: iteration        5/  868457 | consumed samples:          960 | consumed tokens:      1966080 | elapsed time per iteration (s): 14.64 | learning rate: 1.573E-06 | global batch size:   192 | lm loss: 1.243966E+01 | loss scale: 4096.0 | grad norm: 0.255 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 13.116 | TFLOPs: 23.99 |
[default3]: iteration        6/  868457 | consumed samples:         1152 | consumed tokens:      2359296 | elapsed time per iteration (s): 14.82 | learning rate: 1.887E-06 | global batch size:   192 | lm loss: 1.244075E+01 | loss scale: 4096.0 | grad norm: 0.259 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 12.957 | TFLOPs: 23.70 |
[default3]: iteration        7/  868457 | consumed samples:         1344 | consumed tokens:      2752512 | elapsed time per iteration (s): 14.66 | learning rate: 2.202E-06 | global batch size:   192 | lm loss: 1.243877E+01 | loss scale: 4096.0 | grad norm: 0.260 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 13.099 | TFLOPs: 23.96 |
[default3]: iteration        8/  868457 | consumed samples:         1536 | consumed tokens:      3145728 | elapsed time per iteration (s): 14.65 | learning rate: 2.517E-06 | global batch size:   192 | lm loss: 1.243609E+01 | loss scale: 4096.0 | grad norm: 0.270 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 13.108 | TFLOPs: 23.97 |
[default3]: iteration        9/  868457 | consumed samples:         1728 | consumed tokens:      3538944 | elapsed time per iteration (s): 14.61 | learning rate: 2.831E-06 | global batch size:   192 | lm loss: 1.243604E+01 | loss scale: 4096.0 | grad norm: 0.270 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 13.144 | TFLOPs: 24.04 |
```