### PR TITLE
disable CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,10 @@ name: Run all tests
 on:
   # enable to manually trigger the tests
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "**.py"
+# re-enable if we want automatic CI again
+#  pull_request:
+#    paths:
+#      - "**.py"
 
 jobs:
 


### PR DESCRIPTION
as there is no active development at the moment disable automatic CI to avoid burning resources while we develop various related scripts which don't use Meg-DS core.

the manual trigger is still enabled if needed to run the CI on demand.